### PR TITLE
Change static ios framework name to stt_ios from coqui_stt_ios

### DIFF
--- a/native_client/BUILD
+++ b/native_client/BUILD
@@ -210,7 +210,7 @@ tf_cc_shared_object(
 )
 
 ios_static_framework(
-    name = "coqui_stt_ios",
+    name = "stt_ios",
     deps = [":coqui_stt_bundle"],
     families = ["iphone", "ipad"],
     minimum_os_version = "9.0",


### PR DESCRIPTION
This changes the name of the ios framework to `stt_ios` to be compatible with the naming that is used in the Xcode projects. Currently you have to manually rename the framework after building it. Alternatively we could change the names in the Xcode projects to `coqui_stt_ios`.
We would also need to change the name in the taskcluster command but that seems to not be touched anymore.