### PR TITLE
Remove libstt.so reference from stt_ios_test project

### DIFF
--- a/native_client/swift/stt_ios_test.xcodeproj/project.pbxproj
+++ b/native_client/swift/stt_ios_test.xcodeproj/project.pbxproj
@@ -56,7 +56,6 @@
 		504EC34124CF4EFD0073C22E /* SpeechRecognitionImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionImpl.swift; sourceTree = "<group>"; };
 		504EC34224CF4EFD0073C22E /* AudioContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioContext.swift; sourceTree = "<group>"; };
 		507CD3A024B61FE400409BBB /* stt_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = stt_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		507CD3A224B61FEA00409BBB /* libstt.so */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libstt.so; sourceTree = "<group>"; };
 		50F787EF2497683900D52237 /* stt_ios_test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = stt_ios_test.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		50F787F22497683900D52237 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		50F787F42497683900D52237 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -102,7 +101,6 @@
 		50F2B0FC2498D6C7007CD876 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				507CD3A224B61FEA00409BBB /* libstt.so */,
 				507CD3A024B61FE400409BBB /* stt_ios.framework */,
 			);
 			name = Frameworks;


### PR DESCRIPTION
Removes `libstt.so` reference from stt_ios_test project because it is not needed because all dependency comes from the framework.

Fixes #1875 