### PR TITLE
Use NVIDIA image in Dockerfile

### DIFF
--- a/Dockerfile.train
+++ b/Dockerfile.train
@@ -1,6 +1,6 @@
 # Please refer to the TRAINING documentation, "Basic Dockerfile for training"
 
-FROM tensorflow/tensorflow:1.15.4-gpu-py3
+FROM nvcr.io/nvidia/tensorflow:21.05-tf1-py3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # We need to purge python3-xdg because it's breaking STT install later with


### PR DESCRIPTION
Use NVIDIA's tensorflow docker image as base for training `Dockerfile.train`. Former image from Tensorflow caused issues on AWS A100 cluster (p4d.24xlarge)