### PR TITLE
Rewrite audio processing of iOS demo app

### DIFF
--- a/native_client/swift/stt_ios.xcodeproj/project.pbxproj
+++ b/native_client/swift/stt_ios.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		505B136524960D550007DADA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		505B136A24960D550007DADA /* stt_iosTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = stt_iosTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		505B137B249619C90007DADA /* stt_ios.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = stt_ios.modulemap; sourceTree = "<group>"; };
-		505B137C24961AF20007DADA /* coqui-stt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = coqui-stt.h; path = ../../coqui-stt.h; sourceTree = "<group>"; };
+		505B137C24961AF20007DADA /* coqui-stt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "coqui-stt.h"; path = "../../coqui-stt.h"; sourceTree = "<group>"; };
 		505B137E24961BA70007DADA /* STT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STT.swift; sourceTree = "<group>"; };
 		AD2FD0F825678F8800314F2E /* stt_ios.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = stt_ios.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */

--- a/native_client/swift/stt_ios_test.xcodeproj/project.pbxproj
+++ b/native_client/swift/stt_ios_test.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		38E76A832683AB0500E8DFA5 /* AudioInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E76A822683AB0500E8DFA5 /* AudioInput.swift */; };
 		504EC34324CF4EFD0073C22E /* SpeechRecognitionImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC34124CF4EFD0073C22E /* SpeechRecognitionImpl.swift */; };
 		504EC34424CF4EFD0073C22E /* AudioContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC34224CF4EFD0073C22E /* AudioContext.swift */; };
 		504EC34524CF4F4F0073C22E /* stt_ios.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 507CD3A024B61FE400409BBB /* stt_ios.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -53,6 +54,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		38E76A822683AB0500E8DFA5 /* AudioInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInput.swift; sourceTree = "<group>"; };
 		504EC34124CF4EFD0073C22E /* SpeechRecognitionImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionImpl.swift; sourceTree = "<group>"; };
 		504EC34224CF4EFD0073C22E /* AudioContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioContext.swift; sourceTree = "<group>"; };
 		507CD3A024B61FE400409BBB /* stt_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = stt_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +141,7 @@
 				50F787FD2497683A00D52237 /* LaunchScreen.storyboard */,
 				50F788002497683A00D52237 /* Info.plist */,
 				50F787FA2497683A00D52237 /* Preview Content */,
+				38E76A822683AB0500E8DFA5 /* AudioInput.swift */,
 			);
 			path = stt_ios_test;
 			sourceTree = "<group>";
@@ -304,6 +307,7 @@
 				504EC34424CF4EFD0073C22E /* AudioContext.swift in Sources */,
 				50F787F32497683900D52237 /* AppDelegate.swift in Sources */,
 				504EC34324CF4EFD0073C22E /* SpeechRecognitionImpl.swift in Sources */,
+				38E76A832683AB0500E8DFA5 /* AudioInput.swift in Sources */,
 				50F787F52497683900D52237 /* SceneDelegate.swift in Sources */,
 				50F787F72497683900D52237 /* ContentView.swift in Sources */,
 			);

--- a/native_client/swift/stt_ios_test.xcodeproj/project.pbxproj
+++ b/native_client/swift/stt_ios_test.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				504EC34224CF4EFD0073C22E /* AudioContext.swift */,
+				38E76A822683AB0500E8DFA5 /* AudioInput.swift */,
 				504EC34124CF4EFD0073C22E /* SpeechRecognitionImpl.swift */,
 				50F787F22497683900D52237 /* AppDelegate.swift */,
 				50F787F42497683900D52237 /* SceneDelegate.swift */,
@@ -141,7 +142,6 @@
 				50F787FD2497683A00D52237 /* LaunchScreen.storyboard */,
 				50F788002497683A00D52237 /* Info.plist */,
 				50F787FA2497683A00D52237 /* Preview Content */,
-				38E76A822683AB0500E8DFA5 /* AudioInput.swift */,
 			);
 			path = stt_ios_test;
 			sourceTree = "<group>";

--- a/native_client/swift/stt_ios_test/AudioInput.swift
+++ b/native_client/swift/stt_ios_test/AudioInput.swift
@@ -6,7 +6,10 @@ class AudioInput {
     private let onData: (_ shorts: [Int16]) -> Void
 
     private let bus: Int = 0
-    private let processingInterval = 0.2
+
+    // Interval to determine the buffer size
+    // regarding the input device's sample rate.
+    private let processingIntervalInMillis = 200
 
     private var audioData: Data = Data()
 
@@ -25,7 +28,7 @@ class AudioInput {
 
         engine.inputNode.installTap(
             onBus: bus,
-            bufferSize: UInt32(processingInterval * inputFormat.sampleRate),
+            bufferSize: UInt32(Double(processingIntervalInMillis / 1000) * inputFormat.sampleRate),
             format: inputFormat,
             block: handleInput
         )

--- a/native_client/swift/stt_ios_test/AudioInput.swift
+++ b/native_client/swift/stt_ios_test/AudioInput.swift
@@ -1,0 +1,75 @@
+import AVFAudio
+
+class AudioInput {
+    private let engine: AVAudioEngine = AVAudioEngine()
+
+    private let converter: AVAudioConverter
+
+    private let onShorts: (_ shorts: UnsafeBufferPointer<Int16>) -> Void
+
+    private let bus: Int = 0
+
+    private var audioData: Data = Data()
+
+    private let outputFormat = AVAudioFormat(
+        commonFormat: AVAudioCommonFormat.pcmFormatInt16,
+        sampleRate: 16000.0,
+        channels: 1,
+        interleaved: true
+    )!
+
+    init(onShorts: @escaping (_ shorts: UnsafeBufferPointer<Int16>) -> Void) {
+        self.onShorts = onShorts
+
+        let inputFormat = engine.inputNode.outputFormat(forBus: bus)
+        self.converter = AVAudioConverter(from: inputFormat, to: outputFormat)!
+
+        engine.inputNode.installTap(
+            onBus: bus,
+            bufferSize: 2048,
+            format: inputFormat,
+            block: handleInput
+        )
+    }
+
+    // inspired by https://stackoverflow.com/a/40823574/8170620
+    private func handleInput(buffer: AVAudioPCMBuffer, time: AVAudioTime) {
+        var newBufferAvailable = true
+
+        let inputCallback: AVAudioConverterInputBlock = { inNumPackets, outStatus in
+            if newBufferAvailable {
+                outStatus.pointee = .haveData
+                newBufferAvailable = false
+                return buffer
+            } else {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+        }
+
+        let convertedBuffer = AVAudioPCMBuffer(
+            pcmFormat: self.outputFormat,
+            frameCapacity: AVAudioFrameCount(self.outputFormat.sampleRate) * buffer.frameLength / AVAudioFrameCount(buffer.format.sampleRate)
+        )!
+
+        var error: NSError?
+        let status = converter.convert(to: convertedBuffer, error: &error, withInputFrom: inputCallback)
+        assert(status != .error)
+
+        let shorts = UnsafeBufferPointer(
+            start: convertedBuffer.int16ChannelData!.pointee,
+            count: Int(convertedBuffer.frameLength)
+        )
+
+        onShorts(shorts)
+    }
+
+    func start() {
+        engine.prepare()
+        try! engine.start()
+    }
+
+    func stop() {
+        engine.stop()
+    }
+}

--- a/native_client/swift/stt_ios_test/ContentView.swift
+++ b/native_client/swift/stt_ios_test/ContentView.swift
@@ -9,38 +9,61 @@
 import SwiftUI
 
 struct ContentView: View {
-    private var stt = SpeechRecognitionImpl()
     @State var isRecognizingMicrophone = false
+    @State var partialResult = ""
+    @State var result = ""
+    @State var stt: SpeechRecognitionImpl? = nil
+
+    func setup() {
+        stt = SpeechRecognitionImpl(
+            onPartialResult: { nextPartialResult in
+                partialResult = nextPartialResult
+            },
+            onResult: { nextResult in
+                result = nextResult
+            }
+        )
+    }
 
     var body: some View {
         VStack {
             Text("Coqui STT iOS Demo")
                 .font(.system(size: 30))
-            Button("Recognize files", action: recognizeFiles)
-                .padding(30)
-            Button(
-                isRecognizingMicrophone
-                    ? "Stop Microphone Recognition"
-                    : "Start Microphone Recognition",
-                action: isRecognizingMicrophone
-                    ? stopMicRecognition
-                    : startMicRecognition)
-                .padding(30)
+
+            if (stt != nil) {
+                Button("Recognize files", action: recognizeFiles)
+                    .padding(30)
+                Button(
+                    isRecognizingMicrophone
+                        ? "Stop Microphone Recognition"
+                        : "Start Microphone Recognition",
+                    action: isRecognizingMicrophone
+                        ? stopMicRecognition
+                        : startMicRecognition)
+                    .padding(30)
+                Text("Partial result")
+                Text(partialResult)
+                Text("Result")
+                Text(result)
+            } else {
+                Button("Setup", action: setup)
+                    .padding(30)
+            }
         }
     }
 
     func recognizeFiles() {
-        self.stt.recognizeFiles()
+        stt?.recognizeFiles()
     }
 
     func startMicRecognition() {
         isRecognizingMicrophone = true
-        self.stt.startMicrophoneRecognition()
+        stt?.startMicrophoneRecognition()
     }
 
     func stopMicRecognition() {
         isRecognizingMicrophone = false
-        self.stt.stopMicrophoneRecognition()
+        stt?.stopMicrophoneRecognition()
     }
 }
 

--- a/native_client/swift/stt_ios_test/SpeechRecognitionImpl.swift
+++ b/native_client/swift/stt_ios_test/SpeechRecognitionImpl.swift
@@ -16,8 +16,14 @@ class SpeechRecognitionImpl {
     private var model: STTModel
     private var stream: STTStream?
 
-    private let modelFeedInterval = 0.1
-    private let decodeInterval = 0.5
+    // The interval in which audio data is read from
+    // the buffer queue and fed into the model.
+    // Should be slightly higher than [AudioInput.processingIntervalInMillis].
+    private let modelFeedIntervalInMillis = 100
+
+    // The interval in which the model passes data through the decoder.
+    // Should be slightly above timestep length (20 ms) * number of timestamps in a block (default is 16).
+    private let decodeIntervalInMillis = 350
 
     private var audioData = Data()
     private var feedTimer: Timer? = nil
@@ -51,7 +57,7 @@ class SpeechRecognitionImpl {
         audioInput!.start()
 
         feedTimer = Timer.scheduledTimer(
-            withTimeInterval: modelFeedInterval,
+            withTimeInterval: Double(modelFeedIntervalInMillis) / 1000.0,
             repeats: true
         ) { _ in
             if (!self.bufferQueue.isEmpty) {
@@ -66,7 +72,7 @@ class SpeechRecognitionImpl {
         }
 
         decodeTimer = Timer.scheduledTimer(
-            withTimeInterval: decodeInterval,
+            withTimeInterval: Double(decodeIntervalInMillis) / 1000.0,
             repeats: true
         ) { _ in
             // (optional) get partial result


### PR DESCRIPTION
Hey there!

This MR removes the overly complicated audio processing of the iOS demo app with a simpler implementation which uses `AVFAudio`. Tried it out and it works very well. 

Some observations I made along the way:
- `AVAudioEngine` alone does not really allow sample rate conversions, therefore I am using `AVAudioConverter` for that
- There is `AVAudioFile` for writing audio files but it gave errors while writing so I just write the raw bytes into a PCM file like before