### PR TITLE
Fix #1955 Use local source instead of redownloading in Dockerfile.build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,9 +3,6 @@
 # Need devel version cause we need /usr/include/cudnn.h
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
-ARG STT_REPO=https://github.com/coqui-ai/STT.git
-ARG STT_SHA=origin/main
-
 # >> START Install base software
 
 # Get basic packages
@@ -112,12 +109,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
 # << END Configure Bazel
 
 WORKDIR /
-
-RUN git clone --recursive $STT_REPO STT
-WORKDIR /STT
-RUN git checkout $STT_SHA
-RUN git submodule sync tensorflow/
-RUN git submodule update --init tensorflow/
+COPY . /STT/
 
 # >> START Build and bind
 

--- a/doc/DEPLOYMENT.rst
+++ b/doc/DEPLOYMENT.rst
@@ -184,13 +184,24 @@ Dockerfile for building from source
 
 We provide ``Dockerfile.build`` to automatically build ``libstt.so``, the C++ native client, Python bindings, and KenLM.
 
-If you want to specify a different repository or branch, you can specify the ``STT_REPO`` or ``STT_SHA`` arguments:
+Before building, make sure that git submodules have been initialised:
 
 .. code-block:: bash
 
-   docker build . -f Dockerfile.build --build-arg STT_REPO=git://your/fork --build-arg STT_SHA=origin/your-branch
+   git submodule sync
+   git submodule update --init
+   
+Then build with:
 
-.. _runtime-deps:
+.. code-block:: bash
+
+   docker build . -f Dockerfile.build -t stt-image
+   
+You can then use stt inside the Docker container:
+
+.. code-block:: bash
+
+   docker run -it stt-image bash
 
 
 Runtime Dependencies


### PR DESCRIPTION
Make Dockerfile.build copy the current checked out source code into the Docker image instead of downloading a fresh clone.
This was useful to me, saved time and effort and allowed me to easily build the specific tag / commit that I was working on at the time.