### PR TITLE
Add intermediateDecodeExpensive() function and Python binding

### DIFF
--- a/ci_scripts/asserts.sh
+++ b/ci_scripts/asserts.sh
@@ -610,6 +610,8 @@ run_js_streaming_inference_tests()
   status=$?
   set -e
   assert_correct_ldc93s1_lm "${phrase_pbmodel_withlm}" "$status"
+
+  stt --model ${CI_TMP_DIR}/${model_name} --scorer ${CI_TMP_DIR}/kenlm.scorer --audio ${CI_TMP_DIR}/${ldc93s1_sample_filename} --stream --extended --flush
 }
 
 run_js_streaming_prod_inference_tests()

--- a/native_client/coqui-stt.h
+++ b/native_client/coqui-stt.h
@@ -323,6 +323,45 @@ Metadata* STT_IntermediateDecodeWithMetadata(const StreamingState* aSctx,
                                              unsigned int aNumResults);
 
 /**
+ * @brief Compute the intermediate decoding of an ongoing streaming inference, flushing
+ *        buffers first. This ensures that all audio that has been streamed so far is
+ *        included in the result, but is more expensive than STT_IntermediateDecode()
+ *        because buffers are processed through the acoustic model. Calling this function
+ *        too often will also degrade transcription accuracy due to trashing of the
+ *        LSTM hidden state vectors.
+ *
+ * @param aSctx A streaming state pointer returned by {@link STT_CreateStream()}.
+ *
+ * @return The STT result. The user is responsible for freeing the string using
+ *         {@link STT_FreeString()}.
+ *
+ * @note This method will free the state pointer (@p aSctx).
+ */
+STT_EXPORT
+char* STT_IntermediateDecodeFlushBuffers(StreamingState* aSctx);
+
+/**
+ * @brief Compute the intermediate decoding of an ongoing streaming inference, flushing
+ *        buffers first. This ensures that all audio that has been streamed so far is
+ *        included in the result, but is more expensive than
+ *        STT_IntermediateDecodeWithMetadata() because buffers are processed through
+ *        the acoustic model. Calling this function too often will also degrade
+ *        transcription accuracy due to trashing of the LSTM hidden state vectors.
+ *        Return results including metadata.
+ *
+ * @param aSctx A streaming state pointer returned by {@link STT_CreateStream()}.
+ * @param aNumResults The number of candidate transcripts to return.
+ *
+ * @return Metadata struct containing multiple candidate transcripts. Each transcript
+ *         has per-token metadata including timing information. The user is
+ *         responsible for freeing Metadata by calling {@link STT_FreeMetadata()}.
+ *         Returns NULL on error.
+ */
+STT_EXPORT
+Metadata* STT_IntermediateDecodeWithMetadataFlushBuffers(StreamingState* aSctx,
+                                                         unsigned int aNumResults);
+
+/**
  * @brief Compute the final decoding of an ongoing streaming inference and return
  *        the result. Signals the end of an ongoing streaming inference.
  *

--- a/native_client/javascript/index.ts
+++ b/native_client/javascript/index.ts
@@ -107,6 +107,26 @@ class StreamImpl {
     }
 
     /**
+     * Compute the intermediate decoding of an ongoing streaming inference, flushing buffers first. This ensures that all audio that has been streamed so far is included in the result, but is more expensive than intermediateDecode() because buffers are processed through the acoustic model.
+     *
+     * @return The STT intermediate result.
+     */
+    intermediateDecodeFlushBuffers(): string {
+        return binding.IntermediateDecodeFlushBuffers(this._impl);
+    }
+
+    /**
+     * Compute the intermediate decoding of an ongoing streaming inference, flushing buffers first. This ensures that all audio that has been streamed so far is included in the result, but is more expensive than intermediateDecodeWithMetadata() because buffers are processed through the acoustic model. Return results including metadata.
+     *
+     * @param aNumResults Maximum number of candidate transcripts to return. Returned list might be smaller than this. Default value is 1 if not specified.
+     *
+     * @return :js:func:`Metadata` object containing multiple candidate transcripts. Each transcript has per-token metadata including timing information. The user is responsible for freeing Metadata by calling :js:func:`FreeMetadata`. Returns undefined on error.
+     */
+    intermediateDecodeWithMetadataFlushBuffers(aNumResults: number = 1): Metadata {
+        return binding.IntermediateDecodeWithMetadataFlushBuffers(this._impl, aNumResults);
+    }
+
+    /**
      * Compute the final decoding of an ongoing streaming inference and return the result. Signals the end of an ongoing streaming inference.
      *
      * @return The STT result.

--- a/native_client/javascript/stt.i
+++ b/native_client/javascript/stt.i
@@ -35,6 +35,7 @@ using namespace node;
 
 %newobject STT_SpeechToText;
 %newobject STT_IntermediateDecode;
+%newobject STT_IntermediateDecodeFlushBuffers;
 %newobject STT_FinishStream;
 %newobject STT_Version;
 %newobject STT_ErrorCodeToErrorMessage;

--- a/native_client/python/__init__.py
+++ b/native_client/python/__init__.py
@@ -281,6 +281,48 @@ class Stream(object):
             )
         return stt.impl.IntermediateDecodeWithMetadata(self._impl, num_results)
 
+    def intermediateDecodeFlushBuffers(self):
+        """
+        Compute the intermediate decoding of an ongoing streaming inference, flushing
+        buffers first. This ensures that all audio that has been streamed so far is
+        included in the result, but is more expensive than intermediateDecode() because
+        buffers are processed through the acoustic model.
+
+        :return: The STT intermediate result.
+        :type: str
+
+        :throws: RuntimeError if the stream object is not valid
+        """
+        if not self._impl:
+            raise RuntimeError(
+                "Stream object is not valid. Trying to decode an already finished stream?"
+            )
+        return stt.impl.intermediateDecodeFlushBuffers(self._impl)
+
+    def intermediateDecodeWithMetadataFlushBuffers(self, num_results=1):
+        """
+        Compute the intermediate decoding of an ongoing streaming inference, flushing
+        buffers first. This ensures that all audio that has been streamed so far is
+        included in the result, but is more expensive than intermediateDecode() because
+        buffers are processed through the acoustic model. Return results including
+        metadata.
+
+        :param num_results: Maximum number of candidate transcripts to return. Returned list might be smaller than this.
+        :type num_results: int
+
+        :return: Metadata object containing multiple candidate transcripts. Each transcript has per-token metadata including timing information.
+        :type: :func:`Metadata`
+
+        :throws: RuntimeError if the stream object is not valid
+        """
+        if not self._impl:
+            raise RuntimeError(
+                "Stream object is not valid. Trying to decode an already finished stream?"
+            )
+        return stt.impl.intermediateDecodeWithMetadataFlushBuffers(
+            self._impl, num_results
+        )
+
     def finishStream(self):
         """
         Compute the final decoding of an ongoing streaming inference and return

--- a/native_client/python/impl.i
+++ b/native_client/python/impl.i
@@ -119,6 +119,7 @@ static PyObject *parent_reference() {
 
 %newobject STT_SpeechToText;
 %newobject STT_IntermediateDecode;
+%newobject STT_IntermediateDecodeFlushBuffers;
 %newobject STT_FinishStream;
 %newobject STT_Version;
 %newobject STT_ErrorCodeToErrorMessage;

--- a/native_client/stt.cc
+++ b/native_client/stt.cc
@@ -73,7 +73,7 @@ struct StreamingState {
   void feedAudioContent(const short* buffer, unsigned int buffer_size);
   char* intermediateDecode() const;
   Metadata* intermediateDecodeWithMetadata(unsigned int num_results) const;
-  void finalizeStream();
+  void flushBuffers(bool addZeroMfccVectors = false);
   char* finishStream();
   Metadata* finishStreamWithMetadata(unsigned int num_results);
 
@@ -140,14 +140,14 @@ StreamingState::intermediateDecodeWithMetadata(unsigned int num_results) const
 char*
 StreamingState::finishStream()
 {
-  finalizeStream();
+  flushBuffers(true);
   return model_->decode(decoder_state_);
 }
 
 Metadata*
 StreamingState::finishStreamWithMetadata(unsigned int num_results)
 {
-  finalizeStream();
+  flushBuffers(true);
   return model_->decode_metadata(decoder_state_, num_results);
 }
 
@@ -162,19 +162,22 @@ StreamingState::processAudioWindow(const vector<float>& buf)
 }
 
 void
-StreamingState::finalizeStream()
+StreamingState::flushBuffers(bool addZeroMfccVectors)
 {
   // Flush audio buffer
   processAudioWindow(audio_buffer_);
 
-  // Add empty mfcc vectors at end of sample
-  for (int i = 0; i < model_->n_context_; ++i) {
-    addZeroMfccWindow();
+  if (addZeroMfccVectors) {
+    // Add empty mfcc vectors at end of sample
+    for (int i = 0; i < model_->n_context_; ++i) {
+      addZeroMfccWindow();
+    }
   }
 
-  // Process final batch
+  // Process batch if there's inputs to be processed
   if (batch_buffer_.size() > 0) {
     processBatch(batch_buffer_, batch_buffer_.size()/model_->mfcc_feats_per_timestep_);
+    batch_buffer_.resize(0);
   }
 }
 
@@ -450,6 +453,21 @@ Metadata*
 STT_IntermediateDecodeWithMetadata(const StreamingState* aSctx,
                                   unsigned int aNumResults)
 {
+  return aSctx->intermediateDecodeWithMetadata(aNumResults);
+}
+
+char*
+STT_IntermediateDecodeFlushBuffers(StreamingState* aSctx)
+{
+  aSctx->flushBuffers();
+  return aSctx->intermediateDecode();
+}
+
+Metadata*
+STT_IntermediateDecodeWithMetadataFlushBuffers(StreamingState* aSctx,
+                                               unsigned int aNumResults)
+{
+  aSctx->flushBuffers();
   return aSctx->intermediateDecodeWithMetadata(aNumResults);
 }
 

--- a/native_client/tflitemodelstate.cc
+++ b/native_client/tflitemodelstate.cc
@@ -364,7 +364,7 @@ TFLiteModelState::infer(const vector<float>& mfcc,
   const size_t num_classes = alphabet_.GetSize() + 1; // +1 for blank
 
   // Feeding input_node
-  copy_vector_to_tensor(mfcc, input_node_idx_, n_frames*mfcc_feats_per_timestep_);
+  copy_vector_to_tensor(mfcc, input_node_idx_, n_steps_*mfcc_feats_per_timestep_);
 
   // Feeding previous_state_c, previous_state_h
   assert(previous_state_c.size() == state_size_);
@@ -395,7 +395,7 @@ TFLiteModelState::compute_mfcc(const vector<float>& samples,
                                vector<float>& mfcc_output)
 {
   // Feeding input_node
-  copy_vector_to_tensor(samples, input_samples_idx_, samples.size());
+  copy_vector_to_tensor(samples, input_samples_idx_, audio_win_len_);
 
   TfLiteStatus status = interpreter_->SetExecutionPlan(mfcc_exec_plan_);
   if (status != kTfLiteOk) {


### PR DESCRIPTION
This flushes the buffer through the acoustic model before returning
an intermediate decode. Provides an alternative to finishStream()
that doesn't end the stream.

Fixes #1953

I added the Python bindings manually, as I haven't used SWIG before. Let me know there's any glaring mistakes. I haven't added any other bindings so if you have any pointers on how to do that I will happily oblige.

Let me know if there's anything else that needs changing!

The function seems to be working very well on our test hardware and is improving command response with the unreliable webrtc VAD a great deal!

Built and tested on v0.10.0-alpha.9 because I couldn't get later versions to compile.