### PR TITLE
fixed duplicate deallocation of stream in Swift STTStream

### DIFF
--- a/native_client/swift/stt_ios/STT.swift
+++ b/native_client/swift/stt_ios/STT.swift
@@ -283,7 +283,10 @@ public class STTStream {
         precondition(streamCtx != nil, "calling method on invalidated Stream")
 
         let result = STT_FinishStreamWithMetadata(streamCtx, UInt32(numResults))!
-        defer { STT_FreeMetadata(result) }
+        defer {
+            STT_FreeMetadata(result)
+            streamCtx = nil
+        }
         return STTMetadata(fromInternal: result)
     }
 }


### PR DESCRIPTION
We changed from `STTStream.finishStream` to `STTStream.finishStreamWithMetadata` and started to experience `EXC_BAD_ACCESS` errors.

```
0   stt_ios                       	0x00000001065fb4dc DecoderState::~DecoderState() + 88
1   stt_ios                       	0x00000001065f9a14 StreamingState::~StreamingState() + 24
2   stt_ios                       	0x00000001065fb230 STT_FreeStream + 16
3   stt_ios                       	0x00000001065f870c STTStream.deinit + 12 (STT.swift:185)
4   stt_ios                       	0x00000001065f870c STTStream.__deallocating_deinit + 20 (STT.swift:183)
```

After long debugging I found out, that this is caused by a duplicate call of `STT_FreeStream`.
`STTStream.finishStreamWithMetadata` does not unset streamCtx, so the destructor of STTStream calles `STT_FreeStream`, however `STT_FreeStream` was already called in `STT_FinishStreamWithMetadata` resulting in the EXC_BAD_ACCESS errors.
