### PR TITLE
Docker.train: copy libkenlm.so from wget-binaries

### DIFF
--- a/Dockerfile.train
+++ b/Dockerfile.train
@@ -85,6 +85,7 @@ RUN mkdir -p /code/kenlm/build/
 COPY --from=kenlm-build /code/kenlm/build/bin /code/kenlm/build/bin
 COPY --from=wget-binaries /convert_graphdef_memmapped_format /code/convert_graphdef_memmapped_format
 COPY --from=wget-binaries /generate_scorer_package /code/generate_scorer_package
+COPY --from=wget-binaries /libkenlm.so /usr/lib/libkenlm.so
 
 # Install STT
 # No need for the decoder since we did it earlier


### PR DESCRIPTION
When running "/code/generate_scorer_package" in an image built from Dockerfile.train, it fails with this error message:
"error while loading shared libraries: libkenlm.so: cannot open shared object file: No such file or directory"

This adds the "libkenlm.so" file to "/usr/lib/" so that it can be found by "generate_scorer_package"