### PR TITLE
Can't train using 20.06-tf1-py on multi disparate RTX GPUs

### DIFF
--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -44,7 +44,7 @@ RUN wget --no-check-certificate https://github.com/reuben/STT/releases/download/
     rm temp.tar.xz
 
 
-FROM nvcr.io/nvidia/tensorflow:21.08-tf1-py3
+FROM nvcr.io/nvidia/tensorflow:20.06-tf1-py3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # We need to purge python3-xdg because


### PR DESCRIPTION
# Training with multiple disparate Nvidia RTX GPUs

## Problem

When you have: 

1. more than one RTX GPU,
2. that they share the same drivers
3. but are not using the same hardware architecture,

> e.g. RTX 3060 & Titan RTX

you won't be able to train using the docker image built from `nvcr.io/nvidia/tensorflow:20.06-tf1-py3`.

As the warning message states : 

> WARNING: Detected NVIDIA NVIDIA GeForce RTX 3060 GPU, which is not yet supported in this version of the container

**This does not affect machines using only one 30 series RTX GPUs** because it doesn't takes the latest drivers to support training with one card.

## Solution

The temporary workaround is to have two separate docker images. One using `nvcr.io/nvidia/tensorflow:21.08-tf1-py3` for training and another to export the models for deployment using `TFLiteConverter()` on `nvcr.io/nvidia/tensorflow:20.06-tf1-py3` as TFLite support was dropped (for tf1) after `v20.06-tf1-py3`.

Although I dislike this solution because it requires the use of two different versions of TensorFlow for training and exporting models, which is bound to accentuate dependecies issues in the futur, I can neither train nor export models without it.

_Note for reviewers: `Dockerfile.export` is an exact copy of the current `Dockerfile.train` from `main` branch_

```zsh
❯ cmp --silent _Dockerfile.train Dockerfile.export && echo $filesarethesame || echo $filearenotthesame
I don't want to say it... but I told you.
```
> Don't trust me, I'm a random guy on the Internet.

I don't think this fix needs to be merged into the main repo though. Not enough people are matching the above creterias for this to be a wide spread issue. But having this branch around would help those of us who like the challenge to compute on disparate GPUs.