### PR TITLE
Remove Python 3.6 from the supported versions in quickstart

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,7 +26,7 @@
 Quickstart
 ^^^^^^^^^^
 
-The fastest way to use a pre-trained 🐸STT model is with the 🐸STT model manager, a tool that lets you quickly test and demo models locally. You'll need Python 3.6, 3.7, 3.8 or 3.9:
+The fastest way to use a pre-trained 🐸STT model is with the 🐸STT model manager, a tool that lets you quickly test and demo models locally. You'll need Python 3.7, 3.8 or 3.9:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Hi, I wanted to try the quickstart commands at 
https://stt.readthedocs.io/en/latest/
on my desktop Ubuntu 18.04 with
```
$ python3 -V
Python 3.6.9
```
but I got the error
```
$ stt-model-manager
Traceback (most recent call last):
  File "/home/vincentfretin/venv-stt/bin/stt-model-manager", line 5, in <module>
    from coqui_stt_model_manager.__main__ import main
  File "/home/vincentfretin/venv-stt/lib/python3.6/site-packages/coqui_stt_model_manager/__main__.py", line 9, in <module>
    from .server import build_app, get_server_hostport, start_app
  File "/home/vincentfretin/venv-stt/lib/python3.6/site-packages/coqui_stt_model_manager/server.py", line 11, in <module>
    from queue import SimpleQueue
ImportError: cannot import name 'SimpleQueue'
```

[queue.SimpleQueue](https://docs.python.org/3/library/queue.html#queue.SimpleQueue) was introduced in Python 3.7.

I'm guessing you don't want to maintain too old python versions.
I'll just build the latest Python to be able to test all that. :)
Here is just a small PR to remove Python 3.6 in the quickstart section.
You may want to add Python 3.10 if it's compatible?
