### PR TITLE
Enable loading model and scorer from buffer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,14 @@
 .git/lfs
+.git/lost-found
 native_client/ds-swig
 native_client/python/dist/*.whl
 native_client/ctcdecode/*.a
 native_client/javascript/build/
+native_client/javascript/headers/
+native_client/javascript/lib/
+native_client/java/libstt/build/
+native_client/java/libstt/libs/
+*.scorer
+*.pbmm
+*.pb
+*.tflite

--- a/.github/actions/multistrap/action.yml
+++ b/.github/actions/multistrap/action.yml
@@ -29,7 +29,12 @@ runs:
           multistrap_conf=multistrap_armbian64_buster.conf
         fi
 
-        multistrap -d ${{ env.SYSTEM_RASPBIAN }} -f ${{ github.workspace }}/native_client/${multistrap_conf}
+        # Retry 2 times because Rasbian mirrors are often failing
+        if ! multistrap -d ${{ env.SYSTEM_RASPBIAN }} -f ${{ github.workspace }}/native_client/${multistrap_conf}; then
+          if ! multistrap -d ${{ env.SYSTEM_RASPBIAN }} -f ${{ github.workspace }}/native_client/${multistrap_conf}; then
+            multistrap -d ${{ env.SYSTEM_RASPBIAN }} -f ${{ github.workspace }}/native_client/${multistrap_conf}
+          fi
+        fi
 
         if [ ! -z "${{ inputs.packages }}" ]; then
           TO_MOUNT=${{ github.workspace }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -332,7 +332,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends xz-utils zip
+          apt-get install -y --no-install-recommends xz-utils zip liblzma-dev libbz2-dev
       - id: get_cache_key
         uses: ./.github/actions/get_cache_key
         with:
@@ -400,7 +400,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends xz-utils
+          apt-get install -y --no-install-recommends xz-utils liblzma-dev libbz2-dev
       - name: Extract native_client.tar.xz
         run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/

--- a/ci_scripts/asserts.sh
+++ b/ci_scripts/asserts.sh
@@ -595,6 +595,12 @@ run_cpp_only_inference_tests()
   status=$?
   set -e
   assert_correct_ldc93s1_lm "${phrase_pbmodel_withlm_intermediate_decode}" "$status"
+
+  set +e
+  phrase_pbmodel_withlm_intermediate_decode=$(stt --model ${CI_TMP_DIR}/${model_name} --scorer ${CI_TMP_DIR}/kenlm.scorer --audio ${CI_TMP_DIR}/${ldc93s1_sample_filename} --init_from_bytes 2>${CI_TMP_DIR}/stderr | tail -n 1)
+  status=$?
+  set -e
+  assert_correct_ldc93s1_lm "${phrase_pbmodel_withlm_intermediate_decode}" "$status"
 }
 
 run_js_streaming_inference_tests()

--- a/doc/C-Examples.rst
+++ b/doc/C-Examples.rst
@@ -8,10 +8,13 @@ Creating a model instance and loading model
 
 .. literalinclude:: ../native_client/client.cc
    :language: c
-   :linenos:
-   :lineno-match:
-   :start-after: sphinx-doc: c_ref_model_start
-   :end-before: sphinx-doc: c_ref_model_stop
+   :start-after: sphinx-doc: c_ref_model_1_start
+   :end-before: sphinx-doc: c_ref_model_1_stop
+
+.. literalinclude:: ../native_client/client.cc
+   :language: c
+   :start-after: sphinx-doc: c_ref_model_2_start
+   :end-before: sphinx-doc: c_ref_model_2_stop
 
 Transcribing audio with the loaded model
 ----------------------------------------

--- a/native_client/Makefile
+++ b/native_client/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -f stt
 
 $(STT_BIN): client.cc Makefile
-	$(CXX) $(CFLAGS) $(CFLAGS_STT) $(SOX_CFLAGS) client.cc $(LDFLAGS) $(SOX_LDFLAGS) -llzma -lbz2
+	$(CXX) $(CFLAGS) $(CFLAGS_STT) $(SOX_CFLAGS) client.cc $(LDFLAGS) $(SOX_LDFLAGS)
 ifeq ($(OS),Darwin)
 	install_name_tool -change bazel-out/local-opt/bin/native_client/libstt.so @rpath/libstt.so stt
 endif

--- a/native_client/Makefile
+++ b/native_client/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -f stt
 
 $(STT_BIN): client.cc Makefile
-	$(CXX) $(CFLAGS) $(CFLAGS_STT) $(SOX_CFLAGS) client.cc $(LDFLAGS) $(SOX_LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGS_STT) $(SOX_CFLAGS) client.cc $(LDFLAGS) $(SOX_LDFLAGS) -llzma -lbz2
 ifeq ($(OS),Darwin)
 	install_name_tool -change bazel-out/local-opt/bin/native_client/libstt.so @rpath/libstt.so stt
 endif

--- a/native_client/args.h
+++ b/native_client/args.h
@@ -34,6 +34,8 @@ bool extended_metadata = false;
 
 bool json_output = false;
 
+bool init_from_array_of_bytes = false;
+
 int json_candidate_transcripts = 3;
 
 int stream_size = 0;
@@ -62,6 +64,7 @@ void PrintHelp(const char* bin)
     "\t--stream size\t\t\tRun in stream mode, output intermediate results\n"
     "\t--extended_stream size\t\t\tRun in stream mode using metadata output, output intermediate results\n"
     "\t--hot_words\t\t\tHot-words and their boosts. Word:Boost pairs are comma-separated\n"
+    "\t--init_from_bytes\t\tTest init model and scorer from array of bytes\n"
     "\t--help\t\t\t\tShow help\n"
     "\t--version\t\t\tPrint version and exits\n";
     char* version = STT_Version();
@@ -83,6 +86,7 @@ bool ProcessArgs(int argc, char** argv)
             {"t", no_argument, nullptr, 't'},
             {"extended", no_argument, nullptr, 'e'},
             {"json", no_argument, nullptr, 'j'},
+            {"init_from_bytes", no_argument, nullptr, 'B'},
             {"candidate_transcripts", required_argument, nullptr, 150},
             {"stream", required_argument, nullptr, 's'},
             {"extended_stream", required_argument, nullptr, 'S'},
@@ -138,6 +142,10 @@ bool ProcessArgs(int argc, char** argv)
 
         case 'j':
             json_output = true;
+            break;
+
+        case 'B':
+            init_from_array_of_bytes = true;
             break;
 
         case 150:

--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -452,10 +452,9 @@ main(int argc, char **argv)
     return 1;
   }
 
-
-
   // Initialise STT
   ModelState* ctx;
+  std::string am_buffer_raii_holder;
 
   if (!init_from_array_of_bytes) {
     // sphinx-doc: c_ref_model_1_start
@@ -483,6 +482,7 @@ main(int argc, char **argv)
       STT_FreeString(error);
       return 1;
     }
+    am_buffer_raii_holder = std::move(buffer_model_str);
   }
 
   int status = 0;

--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -33,6 +33,8 @@
 #include <unistd.h>
 #endif // NO_DIR
 #include <vector>
+#include <iostream>
+#include <fstream>
 
 #include "coqui-stt.h"
 #include "args.h"
@@ -40,7 +42,7 @@
 typedef struct {
   const char* string;
   double cpu_time_overall;
-} ds_result;
+} stt_result;
 
 struct meta_word {
   std::string word;
@@ -158,13 +160,13 @@ MetadataToJSON(Metadata* result)
   return strdup(out_string.str().c_str());
 }
 
-ds_result
+stt_result
 LocalDsSTT(ModelState* aCtx, const short* aBuffer, size_t aBufferSize,
            bool extended_output, bool json_output)
 {
-  ds_result res = {0};
+  stt_result res = {0};
 
-  clock_t ds_start_time = clock();
+  clock_t stt_start_time = clock();
 
   // sphinx-doc: c_ref_inference_start
   if (extended_output) {
@@ -242,10 +244,10 @@ LocalDsSTT(ModelState* aCtx, const short* aBuffer, size_t aBufferSize,
   }
   // sphinx-doc: c_ref_inference_stop
 
-  clock_t ds_end_infer = clock();
+  clock_t stt_end_infer = clock();
 
   res.cpu_time_overall =
-    ((double) (ds_end_infer - ds_start_time)) / CLOCKS_PER_SEC;
+    ((double) (stt_end_infer - stt_start_time)) / CLOCKS_PER_SEC;
 
   return res;
 }
@@ -253,12 +255,12 @@ LocalDsSTT(ModelState* aCtx, const short* aBuffer, size_t aBufferSize,
 typedef struct {
   char*  buffer;
   size_t buffer_size;
-} ds_audio_buffer;
+} stt_audio_buffer;
 
-ds_audio_buffer
+stt_audio_buffer
 GetAudioBuffer(const char* path, int desired_sample_rate)
 {
-  ds_audio_buffer res = {0};
+  stt_audio_buffer res = {0};
 
 #ifndef NO_SOX
   sox_format_t* input = sox_open_read(path, NULL, NULL, NULL);
@@ -404,12 +406,12 @@ GetAudioBuffer(const char* path, int desired_sample_rate)
 void
 ProcessFile(ModelState* context, const char* path, bool show_times)
 {
-  ds_audio_buffer audio = GetAudioBuffer(path, STT_GetModelSampleRate(context));
+  stt_audio_buffer audio = GetAudioBuffer(path, STT_GetModelSampleRate(context));
 
   // Pass audio to STT
   // We take half of buffer_size because buffer is a char* while
   // LocalDsSTT() expected a short*
-  ds_result result = LocalDsSTT(context,
+  stt_result result = LocalDsSTT(context,
                                 (const short*)audio.buffer,
                                 audio.buffer_size / 2,
                                 extended_metadata,
@@ -450,40 +452,78 @@ main(int argc, char **argv)
     return 1;
   }
 
+
+
   // Initialise STT
   ModelState* ctx;
-  // sphinx-doc: c_ref_model_start
-  int status = STT_CreateModel(model, &ctx);
-  if (status != 0) {
-    char* error = STT_ErrorCodeToErrorMessage(status);
-    fprintf(stderr, "Could not create model: %s\n", error);
-    free(error);
-    return 1;
+
+  if (!init_from_array_of_bytes) {
+    // sphinx-doc: c_ref_model_1_start
+    ModelState* modelctx;
+    int status = STT_CreateModel(model, &modelctx);
+
+    if (status != STT_ERR_OK) {
+      char* error = STT_ErrorCodeToErrorMessage(status);
+      fprintf(stderr, "Could not create model: %s\n", error);
+      STT_FreeString(error);
+      return 1;
+    }
+    // sphinx-doc: c_ref_model_1_end
+    ctx = modelctx;
+  } else {
+    // Reading model file to a char * buffer
+    std::ifstream is_model(model, std::ios::binary);
+    std::stringstream buffer_model;
+    buffer_model << is_model.rdbuf();
+    std::string buffer_model_str = buffer_model.str();
+    int status = STT_CreateModelFromBuffer(buffer_model_str.c_str(), buffer_model_str.size(), &ctx);
+    if (status != STT_ERR_OK) {
+      char* error = STT_ErrorCodeToErrorMessage(status);
+      fprintf(stderr, "Could not create model: %s\n", error);
+      STT_FreeString(error);
+      return 1;
+    }
   }
 
+  int status = 0;
   if (set_beamwidth) {
     status = STT_SetModelBeamWidth(ctx, beam_width);
-    if (status != 0) {
+    if (status != STT_ERR_OK) {
       fprintf(stderr, "Could not set model beam width.\n");
       return 1;
     }
   }
 
   if (scorer) {
-    status = STT_EnableExternalScorer(ctx, scorer);
-    if (status != 0) {
-      fprintf(stderr, "Could not enable external scorer.\n");
+    if (!init_from_array_of_bytes) {
+      // sphinx-doc: c_ref_model_2_start
+      status = STT_EnableExternalScorer(ctx, scorer);
+      // sphinx-doc: c_ref_model_2_end
+    } else {
+      // Reading scorer file to a string buffer
+      std::ifstream is_scorer(scorer, std::ios::binary );
+      std::stringstream buffer_scorer;
+      buffer_scorer << is_scorer.rdbuf();
+      std::string tmp_str_scorer = buffer_scorer.str();
+      status = STT_EnableExternalScorerFromBuffer(ctx, tmp_str_scorer.c_str(), tmp_str_scorer.size());
+    }
+
+    // sphinx-doc: c_ref_model_3_start
+    if (status != STT_ERR_OK) {
+      char* error = STT_ErrorCodeToErrorMessage(status);
+      fprintf(stderr, "Could not enable external scorer: %s\n", error);
+      STT_FreeString(error);
       return 1;
     }
+    // sphinx-doc: c_ref_model_3_end
     if (set_alphabeta) {
       status = STT_SetScorerAlphaBeta(ctx, lm_alpha, lm_beta);
-      if (status != 0) {
+      if (status != STT_ERR_OK) {
         fprintf(stderr, "Error setting scorer alpha and beta.\n");
         return 1;
       }
     }
   }
-  // sphinx-doc: c_ref_model_stop
 
   if (hot_words) {
     std::vector<std::string> hot_words_ = SplitStringOnDelim(hot_words, ",");
@@ -495,7 +535,7 @@ main(int argc, char **argv)
       bool boost_is_valid = (pair_[1].find_first_not_of("-.0123456789") == std::string::npos);
       float boost = strtof((pair_[1]).c_str(),0);
       status = STT_AddHotWord(ctx, word, boost);
-      if (status != 0 || !boost_is_valid) {
+      if (status != STT_ERR_OK || !boost_is_valid) {
         fprintf(stderr, "Could not enable hot-word.\n");
         return 1;
       }

--- a/native_client/coqui-stt.h
+++ b/native_client/coqui-stt.h
@@ -116,6 +116,20 @@ int STT_CreateModel(const char* aModelPath,
                     ModelState** retval);
 
 /**
+ * @brief An object providing an interface to a trained Coqui STT model, loaded from a buffer.
+ *
+ * @param aModelBuffer The buffer containing the content of the exported model.
+ * @param aBufferSize Size of model buffer.
+ * @param[out] retval a ModelState pointer
+ *
+ * @return Zero on success, non-zero on failure.
+ */
+STT_EXPORT
+int STT_CreateModelFromBuffer(const char* aModelBuffer,
+                              unsigned int aBufferSize,
+                              ModelState** retval);
+
+/**
  * @brief Get beam width value used by the model. If {@link STT_SetModelBeamWidth}
  *        was not called before, will return the default value loaded from the
  *        model file.
@@ -167,6 +181,20 @@ void STT_FreeModel(ModelState* ctx);
 STT_EXPORT
 int STT_EnableExternalScorer(ModelState* aCtx,
                              const char* aScorerPath);
+
+/**
+ * @brief Enable decoding using an external scorer loaded from a buffer.
+ *
+ * @param aCtx The ModelState pointer for the model being changed.
+ * @param aScorerBuffer The buffer containing the content of an external-scorer file.
+ * @param aBufferSize Size of scorer buffer.
+ *
+ * @return Zero on success, non-zero on failure (invalid arguments).
+ */
+STT_EXPORT
+int STT_EnableExternalScorerFromBuffer(ModelState* aCtx,
+                                       const char* aScorerBuffer,
+                                       unsigned int aBufferSize);
 
 /**
  * @brief Add a hot-word and its boost.

--- a/native_client/ctcdecode/__init__.py
+++ b/native_client/ctcdecode/__init__.py
@@ -105,7 +105,7 @@ class Scorer(swigwrapper.Scorer):
             assert beta is not None, "beta parameter is required"
             assert scorer_path, "scorer_path parameter is required"
 
-            err = self.init(scorer_path.encode("utf-8"), alphabet)
+            err = self.init_from_filepath(scorer_path.encode("utf-8"), alphabet)
             if err != 0:
                 raise ValueError(
                     "Scorer initialization failed with error code 0x{:X}".format(err)

--- a/native_client/ctcdecode/scorer.cpp
+++ b/native_client/ctcdecode/scorer.cpp
@@ -41,22 +41,24 @@ Scorer::~Scorer()
 
 int
 Scorer::init(const std::string& lm_path,
+             bool load_from_bytes,
              const Alphabet& alphabet)
 {
   set_alphabet(alphabet);
-  return load_lm(lm_path);
+  return load_lm(lm_path, load_from_bytes);
 }
 
 int
 Scorer::init(const std::string& lm_path,
+             bool load_from_bytes,
              const std::string& alphabet_config_path)
 {
-  int err = alphabet_.init(alphabet_config_path.c_str());
+  int err = alphabet_.init(alphabet_config_path.c_str()); // Do we need to make this initiable from bytes?
   if (err != 0) {
     return err;
   }
   setup_char_map();
-  return load_lm(lm_path);
+  return load_lm(lm_path, load_from_bytes);
 }
 
 void
@@ -81,45 +83,61 @@ void Scorer::setup_char_map()
   }
 }
 
-int Scorer::load_lm(const std::string& lm_path)
+int Scorer::load_lm(const std::string& lm_string, bool load_from_bytes)
 {
-  // Check if file is readable to avoid KenLM throwing an exception
-  const char* filename = lm_path.c_str();
-  if (access(filename, R_OK) != 0) {
-    return STT_ERR_SCORER_UNREADABLE;
-  }
+  if (!load_from_bytes) {
+    // Check if file is readable to avoid KenLM throwing an exception
+    const char* filename = lm_string.c_str();
+    if (access(filename, R_OK) != 0) {
+      return STT_ERR_SCORER_UNREADABLE;
+    }
 
-  // Check if the file format is valid to avoid KenLM throwing an exception
-  lm::ngram::ModelType model_type;
-  if (!lm::ngram::RecognizeBinary(filename, model_type)) {
-    return STT_ERR_SCORER_INVALID_LM;
+    // Check if the file format is valid to avoid KenLM throwing an exception
+    lm::ngram::ModelType model_type;
+    if (!lm::ngram::RecognizeBinary(filename, model_type)) {
+      return STT_ERR_SCORER_INVALID_LM;
+    }
   }
 
   // Load the LM
   lm::ngram::Config config;
   config.load_method = util::LoadMethod::LAZY;
-  language_model_.reset(lm::ngram::LoadVirtual(filename, config));
+  if (load_from_bytes){
+    language_model_.reset(lm::ngram::LoadVirtual(lm_string.c_str(), lm_string.size(), config));
+  } else {
+    language_model_.reset(lm::ngram::LoadVirtual(lm_string.c_str(), config));
+  }
+
   max_order_ = language_model_->Order();
-
-  uint64_t package_size;
-  {
-    util::scoped_fd fd(util::OpenReadOrThrow(filename));
-    package_size = util::SizeFile(fd.get());
-  }
+  std::stringstream stst;
   uint64_t trie_offset = language_model_->GetEndOfSearchOffset();
-  if (package_size <= trie_offset) {
-    // File ends without a trie structure
-    return STT_ERR_SCORER_NO_TRIE;
+
+  if (!load_from_bytes) {
+    uint64_t package_size;
+    {
+      util::scoped_fd fd(util::OpenReadOrThrow(lm_string.c_str()));
+      package_size = util::SizeFile(fd.get());
+    }
+
+    if (package_size <= trie_offset) {
+      // File ends without a trie structure
+      return STT_ERR_SCORER_NO_TRIE;
+    }
+
+    // Read metadata and trie from file
+    std::ifstream fin(lm_string.c_str(), std::ios::binary);
+    stst << fin.rdbuf();
+  } else {
+    stst = std::stringstream(lm_string);
   }
 
-  // Read metadata and trie from file
-  std::ifstream fin(lm_path, std::ios::binary);
-  fin.seekg(trie_offset);
-  return load_trie(fin, lm_path);
+  stst.seekg(trie_offset);
+  return load_trie(stst, lm_string, load_from_bytes);
 }
 
-int Scorer::load_trie(std::ifstream& fin, const std::string& file_path)
+int Scorer::load_trie(std::stringstream& fin, const std::string& file_path, bool load_from_bytes)
 {
+
   int magic;
   fin.read(reinterpret_cast<char*>(&magic), sizeof(magic));
   if (magic != MAGIC) {
@@ -152,9 +170,13 @@ int Scorer::load_trie(std::ifstream& fin, const std::string& file_path)
   reset_params(alpha, beta);
 
   fst::FstReadOptions opt;
-  opt.mode = fst::FstReadOptions::MAP;
-  opt.source = file_path;
-  dictionary.reset(FstType::Read(fin, opt));
+  if (load_from_bytes) {
+    dictionary.reset(fst::ConstFst<fst::StdArc>::Read(fin, opt));
+  } else {
+    opt.mode = fst::FstReadOptions::MAP;
+    opt.source = file_path;
+    dictionary.reset(FstType::Read(fin, opt));
+  }
   return STT_ERR_OK;
 }
 

--- a/native_client/ctcdecode/scorer.cpp
+++ b/native_client/ctcdecode/scorer.cpp
@@ -1,22 +1,22 @@
 #ifdef _MSC_VER
-  #include <stdlib.h>
-  #include <io.h>
-  #define NOMINMAX
-  #include <windows.h>
+#include <io.h>
+#include <stdlib.h>
+#define NOMINMAX
+#include <windows.h>
 
-  #define R_OK    4       /* Read permission.  */
-  #define W_OK    2       /* Write permission.  */
-  #define F_OK    0       /* Existence.  */
+#define R_OK 4 /* Read permission.  */
+#define W_OK 2 /* Write permission.  */
+#define F_OK 0 /* Existence.  */
 
-  #define access _access
+#define access _access
 
-#else          /* _MSC_VER  */
-  #include <unistd.h>
+#else /* _MSC_VER  */
+#include <unistd.h>
 #endif
 
 #include "scorer.h"
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include "kenlm/lm/config.hh"
 #include "kenlm/lm/model.hh"
@@ -27,38 +27,53 @@
 #include "decoder_utils.h"
 
 using namespace fl::lib::text;
+using namespace std;
 
 static const int32_t MAGIC = 'TRIE';
 static const int32_t FILE_VERSION = 6;
 
-Scorer::Scorer()
-{
-}
+Scorer::Scorer() {}
 
-Scorer::~Scorer()
-{
-}
+Scorer::~Scorer() {}
 
 int
-Scorer::init(const std::string& lm_path,
-             bool load_from_bytes,
-             const Alphabet& alphabet)
+Scorer::init_from_filepath(const string& lm_path, const Alphabet& alphabet)
 {
   set_alphabet(alphabet);
-  return load_lm(lm_path, load_from_bytes);
+  return load_lm_filepath(lm_path);
 }
 
 int
-Scorer::init(const std::string& lm_path,
-             bool load_from_bytes,
-             const std::string& alphabet_config_path)
+Scorer::init_from_filepath(const string& lm_path,
+                           const string& alphabet_config_path)
 {
-  int err = alphabet_.init(alphabet_config_path.c_str()); // Do we need to make this initiable from bytes?
+  Alphabet a;
+  int err = a.init(alphabet_config_path.c_str());
   if (err != 0) {
     return err;
   }
-  setup_char_map();
-  return load_lm(lm_path, load_from_bytes);
+  set_alphabet(a);
+  return load_lm_filepath(lm_path);
+}
+
+int
+Scorer::init_from_buffer(const string& buffer, const Alphabet& alphabet)
+{
+  set_alphabet(alphabet);
+  return load_lm_buffer(buffer);
+}
+
+int
+Scorer::init_from_buffer(const string& buffer,
+                         const string& alphabet_config_path)
+{
+  Alphabet a;
+  int err = a.init(alphabet_config_path.c_str());
+  if (err != 0) {
+    return err;
+  }
+  set_alphabet(a);
+  return load_lm_buffer(buffer);
 }
 
 void
@@ -68,7 +83,8 @@ Scorer::set_alphabet(const Alphabet& alphabet)
   setup_char_map();
 }
 
-void Scorer::setup_char_map()
+void
+Scorer::setup_char_map()
 {
   // (Re-)Initialize character map
   char_map_.clear();
@@ -83,139 +99,161 @@ void Scorer::setup_char_map()
   }
 }
 
-int Scorer::load_lm(const std::string& lm_string, bool load_from_bytes)
+int
+Scorer::load_lm_filepath(const string& path)
 {
-  if (!load_from_bytes) {
-    // Check if file is readable to avoid KenLM throwing an exception
-    const char* filename = lm_string.c_str();
-    if (access(filename, R_OK) != 0) {
-      return STT_ERR_SCORER_UNREADABLE;
-    }
+  // Check if file is readable to avoid KenLM throwing an exception
+  const char* filename = path.c_str();
+  if (access(filename, R_OK) != 0) {
+    return STT_ERR_SCORER_UNREADABLE;
+  }
 
-    // Check if the file format is valid to avoid KenLM throwing an exception
-    lm::ngram::ModelType model_type;
-    if (!lm::ngram::RecognizeBinary(filename, model_type)) {
-      return STT_ERR_SCORER_INVALID_LM;
-    }
+  // Check if the file format is valid to avoid KenLM throwing an exception
+  lm::ngram::ModelType model_type;
+  if (!lm::ngram::RecognizeBinary(filename, model_type)) {
+    return STT_ERR_SCORER_INVALID_LM;
   }
 
   // Load the LM
   lm::ngram::Config config;
   config.load_method = util::LoadMethod::LAZY;
-  if (load_from_bytes){
-    language_model_.reset(lm::ngram::LoadVirtual(lm_string.c_str(), lm_string.size(), config));
-  } else {
-    language_model_.reset(lm::ngram::LoadVirtual(lm_string.c_str(), config));
-  }
+  language_model_.reset(lm::ngram::LoadVirtual(filename, config));
 
   max_order_ = language_model_->Order();
-  std::stringstream stst;
   uint64_t trie_offset = language_model_->GetEndOfSearchOffset();
 
-  if (!load_from_bytes) {
-    uint64_t package_size;
-    {
-      util::scoped_fd fd(util::OpenReadOrThrow(lm_string.c_str()));
-      package_size = util::SizeFile(fd.get());
-    }
-
-    if (package_size <= trie_offset) {
-      // File ends without a trie structure
-      return STT_ERR_SCORER_NO_TRIE;
-    }
-
-    // Read metadata and trie from file
-    std::ifstream fin(lm_string.c_str(), std::ios::binary);
-    stst << fin.rdbuf();
-  } else {
-    stst = std::stringstream(lm_string);
+  uint64_t package_size;
+  {
+    util::scoped_fd fd(util::OpenReadOrThrow(filename));
+    package_size = util::SizeFile(fd.get());
   }
 
-  stst.seekg(trie_offset);
-  return load_trie(stst, lm_string, load_from_bytes);
+  if (package_size <= trie_offset) {
+    // File ends without a trie structure
+    return STT_ERR_SCORER_NO_TRIE;
+  }
+
+  // Read metadata and trie from file
+  ifstream fin(filename, ios::binary);
+  fin.seekg(trie_offset);
+  return load_trie_mmap(fin, path);
 }
 
-int Scorer::load_trie(std::stringstream& fin, const std::string& file_path, bool load_from_bytes)
+int
+Scorer::load_lm_buffer(const string& buffer)
 {
+  // Load the LM
+  lm::ngram::Config config;
+  config.load_method = util::LoadMethod::LAZY;
+  language_model_.reset(
+    lm::ngram::LoadVirtual(buffer.c_str(), buffer.size(), config));
 
+  max_order_ = language_model_->Order();
+
+  uint64_t trie_offset = language_model_->GetEndOfSearchOffset();
+  stringstream stst(buffer);
+  stst.seekg(trie_offset);
+  return load_trie_buffer(stst);
+}
+
+int
+Scorer::load_trie_buffer(stringstream& stream)
+{
+  return load_trie_impl(stream, "", true);
+}
+
+int
+Scorer::load_trie_mmap(ifstream& stream, const string& file_path)
+{
+  return load_trie_impl(stream, file_path, false);
+}
+
+int
+Scorer::load_trie_impl(basic_istream<char>& stream,
+                       const string& file_path,
+                       bool load_from_bytes)
+{
   int magic;
-  fin.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+  stream.read(reinterpret_cast<char*>(&magic), sizeof(magic));
   if (magic != MAGIC) {
-    std::cerr << "Error: Can't parse scorer file, invalid header. Try updating "
-                 "your scorer file." << std::endl;
+    cerr << "Error: Can't parse scorer file, invalid header. Try updating "
+            "your scorer file."
+         << endl;
     return STT_ERR_SCORER_INVALID_TRIE;
   }
 
   int version;
-  fin.read(reinterpret_cast<char*>(&version), sizeof(version));
+  stream.read(reinterpret_cast<char*>(&version), sizeof(version));
   if (version != FILE_VERSION) {
-    std::cerr << "Error: Scorer file version mismatch (" << version
-              << " instead of expected " << FILE_VERSION
-              << "). ";
+    cerr << "Error: Scorer file version mismatch (" << version
+         << " instead of expected " << FILE_VERSION << "). ";
     if (version < FILE_VERSION) {
-      std::cerr << "Update your scorer file.";
+      cerr << "Update your scorer file.";
     } else {
-      std::cerr << "Downgrade your scorer file or update your version of Coqui STT.";
+      cerr << "Downgrade your scorer file or update your version of Coqui STT.";
     }
-    std::cerr << std::endl;
+    cerr << endl;
     return STT_ERR_SCORER_VERSION_MISMATCH;
   }
 
-  fin.read(reinterpret_cast<char*>(&is_utf8_mode_), sizeof(is_utf8_mode_));
+  stream.read(reinterpret_cast<char*>(&is_utf8_mode_), sizeof(is_utf8_mode_));
 
   // Read hyperparameters from header
   double alpha, beta;
-  fin.read(reinterpret_cast<char*>(&alpha), sizeof(alpha));
-  fin.read(reinterpret_cast<char*>(&beta), sizeof(beta));
+  stream.read(reinterpret_cast<char*>(&alpha), sizeof(alpha));
+  stream.read(reinterpret_cast<char*>(&beta), sizeof(beta));
   reset_params(alpha, beta);
 
   fst::FstReadOptions opt;
   if (load_from_bytes) {
-    dictionary.reset(fst::ConstFst<fst::StdArc>::Read(fin, opt));
+    dictionary.reset(fst::ConstFst<fst::StdArc>::Read(stream, opt));
   } else {
     opt.mode = fst::FstReadOptions::MAP;
     opt.source = file_path;
-    dictionary.reset(FstType::Read(fin, opt));
+    dictionary.reset(FstType::Read(stream, opt));
   }
   return STT_ERR_OK;
 }
 
-bool Scorer::save_dictionary(const std::string& path, bool append_instead_of_overwrite)
+bool
+Scorer::save_dictionary(const string& path, bool append_instead_of_overwrite)
 {
-  std::ios::openmode om;
+  ios::openmode om;
   if (append_instead_of_overwrite) {
-    om = std::ios::in|std::ios::out|std::ios::binary|std::ios::ate;
+    om = ios::in | ios::out | ios::binary | ios::ate;
   } else {
-    om = std::ios::out|std::ios::binary;
+    om = ios::out | ios::binary;
   }
-  std::fstream fout(path, om);
-  if (!fout ||fout.bad()) {
-    std::cerr << "Error opening '" << path << "'" << std::endl;
+  fstream fout(path, om);
+  if (!fout || fout.bad()) {
+    cerr << "Error opening '" << path << "'" << endl;
     return false;
   }
   fout.write(reinterpret_cast<const char*>(&MAGIC), sizeof(MAGIC));
   if (fout.bad()) {
-    std::cerr << "Error writing MAGIC '" << path << "'" << std::endl;
+    cerr << "Error writing MAGIC '" << path << "'" << endl;
     return false;
   }
-  fout.write(reinterpret_cast<const char*>(&FILE_VERSION), sizeof(FILE_VERSION));
+  fout.write(reinterpret_cast<const char*>(&FILE_VERSION),
+             sizeof(FILE_VERSION));
   if (fout.bad()) {
-    std::cerr << "Error writing FILE_VERSION '" << path << "'" << std::endl;
+    cerr << "Error writing FILE_VERSION '" << path << "'" << endl;
     return false;
   }
-  fout.write(reinterpret_cast<const char*>(&is_utf8_mode_), sizeof(is_utf8_mode_));
+  fout.write(reinterpret_cast<const char*>(&is_utf8_mode_),
+             sizeof(is_utf8_mode_));
   if (fout.bad()) {
-    std::cerr << "Error writing is_utf8_mode '" << path << "'" << std::endl;
+    cerr << "Error writing is_utf8_mode '" << path << "'" << endl;
     return false;
   }
   fout.write(reinterpret_cast<const char*>(&alpha), sizeof(alpha));
   if (fout.bad()) {
-    std::cerr << "Error writing alpha '" << path << "'" << std::endl;
+    cerr << "Error writing alpha '" << path << "'" << endl;
     return false;
   }
   fout.write(reinterpret_cast<const char*>(&beta), sizeof(beta));
   if (fout.bad()) {
-    std::cerr << "Error writing beta '" << path << "'" << std::endl;
+    cerr << "Error writing beta '" << path << "'" << endl;
     return false;
   }
   fst::FstWriteOptions opt;
@@ -224,14 +262,16 @@ bool Scorer::save_dictionary(const std::string& path, bool append_instead_of_ove
   return dictionary->Write(fout, opt);
 }
 
-bool Scorer::is_scoring_boundary(PathTrie* prefix, size_t new_label)
+bool
+Scorer::is_scoring_boundary(PathTrie* prefix, size_t new_label)
 {
   if (is_utf8_mode()) {
     if (prefix->character == -1) {
       return false;
     }
     unsigned char first_byte;
-    int distance_to_boundary = prefix->distance_to_codepoint_boundary(&first_byte, alphabet_);
+    int distance_to_boundary =
+      prefix->distance_to_codepoint_boundary(&first_byte, alphabet_);
     int needed_bytes;
     if ((first_byte >> 3) == 0x1E) {
       needed_bytes = 4;
@@ -242,7 +282,8 @@ bool Scorer::is_scoring_boundary(PathTrie* prefix, size_t new_label)
     } else if ((first_byte >> 7) == 0x00) {
       needed_bytes = 1;
     } else {
-      assert(false); // invalid byte sequence. should be unreachable, disallowed by vocabulary/trie
+      assert(false); // invalid byte sequence. should be unreachable, disallowed
+                     // by vocabulary/trie
       return false;
     }
     return distance_to_boundary == needed_bytes;
@@ -251,22 +292,22 @@ bool Scorer::is_scoring_boundary(PathTrie* prefix, size_t new_label)
   }
 }
 
-double Scorer::get_log_cond_prob(const std::vector<std::string>& words,
-                                 bool bos,
-                                 bool eos)
+double
+Scorer::get_log_cond_prob(const vector<string>& words, bool bos, bool eos)
 {
   return get_log_cond_prob(words.begin(), words.end(), bos, eos);
 }
 
-double Scorer::get_log_cond_prob(const std::vector<std::string>::const_iterator& begin,
-                                 const std::vector<std::string>::const_iterator& end,
-                                 bool bos,
-                                 bool eos)
+double
+Scorer::get_log_cond_prob(const vector<string>::const_iterator& begin,
+                          const vector<string>::const_iterator& end,
+                          bool bos,
+                          bool eos)
 {
   const auto& vocab = language_model_->BaseVocabulary();
   lm::ngram::State state_vec[2];
-  lm::ngram::State *in_state = &state_vec[0];
-  lm::ngram::State *out_state = &state_vec[1];
+  lm::ngram::State* in_state = &state_vec[0];
+  lm::ngram::State* out_state = &state_vec[1];
 
   if (bos) {
     language_model_->BeginSentenceWrite(in_state);
@@ -284,29 +325,33 @@ double Scorer::get_log_cond_prob(const std::vector<std::string>::const_iterator&
     }
 
     cond_prob = language_model_->BaseScore(in_state, word_index, out_state);
-    std::swap(in_state, out_state);
+    swap(in_state, out_state);
   }
 
   if (eos) {
-    cond_prob = language_model_->BaseScore(in_state, vocab.EndSentence(), out_state);
+    cond_prob =
+      language_model_->BaseScore(in_state, vocab.EndSentence(), out_state);
   }
 
   // return loge prob
-  return cond_prob/NUM_FLT_LOGE;
+  return cond_prob / NUM_FLT_LOGE;
 }
 
-void Scorer::reset_params(float alpha, float beta)
+void
+Scorer::reset_params(float alpha, float beta)
 {
   this->alpha = alpha;
   this->beta = beta;
 }
 
-std::vector<std::string> Scorer::split_labels_into_scored_units(const std::vector<unsigned int>& labels)
+vector<string>
+Scorer::split_labels_into_scored_units(const vector<unsigned int>& labels)
 {
-  if (labels.empty()) return {};
+  if (labels.empty())
+    return {};
 
-  std::string s = alphabet_.Decode(labels);
-  std::vector<std::string> words;
+  string s = alphabet_.Decode(labels);
+  vector<string> words;
   if (is_utf8_mode_) {
     words = split_into_codepoints(s);
   } else {
@@ -315,9 +360,10 @@ std::vector<std::string> Scorer::split_labels_into_scored_units(const std::vecto
   return words;
 }
 
-std::vector<std::string> Scorer::make_ngram(PathTrie* prefix)
+vector<string>
+Scorer::make_ngram(PathTrie* prefix)
 {
-  std::vector<std::string> ngram;
+  vector<string> ngram;
   PathTrie* current_node = prefix;
   PathTrie* new_node = nullptr;
 
@@ -326,7 +372,7 @@ std::vector<std::string> Scorer::make_ngram(PathTrie* prefix)
       break;
     }
 
-    std::vector<unsigned int> prefix_vec;
+    vector<unsigned int> prefix_vec;
 
     if (is_utf8_mode_) {
       new_node = current_node->get_prev_grapheme(prefix_vec, alphabet_);
@@ -336,14 +382,15 @@ std::vector<std::string> Scorer::make_ngram(PathTrie* prefix)
     current_node = new_node->parent;
 
     // reconstruct word
-    std::string word = alphabet_.Decode(prefix_vec);
+    string word = alphabet_.Decode(prefix_vec);
     ngram.push_back(word);
   }
-  std::reverse(ngram.begin(), ngram.end());
+  reverse(ngram.begin(), ngram.end());
   return ngram;
 }
 
-void Scorer::fill_dictionary(const std::unordered_set<std::string>& vocabulary)
+void
+Scorer::fill_dictionary(const unordered_set<string>& vocabulary)
 {
   // ConstFst is immutable, so we need to use a MutableFst to create the trie,
   // and then we convert to a ConstFst for the decoder and for storing on disk.
@@ -351,7 +398,8 @@ void Scorer::fill_dictionary(const std::unordered_set<std::string>& vocabulary)
   // For each unigram convert to ints and put in trie
   for (const auto& word : vocabulary) {
     if (word != START_TOKEN && word != UNK_TOKEN && word != END_TOKEN) {
-      add_word_to_dictionary(word, char_map_, is_utf8_mode_, SPACE_ID_ + 1, &dictionary);
+      add_word_to_dictionary(
+        word, char_map_, is_utf8_mode_, SPACE_ID_ + 1, &dictionary);
     }
   }
 
@@ -363,7 +411,7 @@ void Scorer::fill_dictionary(const std::unordered_set<std::string>& vocabulary)
    * can greatly increase the size of the FST
    */
   fst::RmEpsilon(&dictionary);
-  std::unique_ptr<fst::StdVectorFst> new_dict(new fst::StdVectorFst);
+  unique_ptr<fst::StdVectorFst> new_dict(new fst::StdVectorFst);
 
   /* This makes the FST deterministic, meaning for any string input there's
    * only one possible state the FST could be in.  It is assumed our
@@ -378,14 +426,14 @@ void Scorer::fill_dictionary(const std::unordered_set<std::string>& vocabulary)
   fst::Minimize(new_dict.get());
 
   // Now we convert the MutableFst to a ConstFst (Scorer::FstType) via its ctor
-  std::unique_ptr<FstType> converted(new FstType(*new_dict));
-  this->dictionary = std::move(converted);
+  unique_ptr<FstType> converted(new FstType(*new_dict));
+  this->dictionary = move(converted);
 }
 
 LMStatePtr
 Scorer::start(bool startWithNothing)
 {
-  auto outState = std::make_shared<KenLMState>();
+  auto outState = make_shared<KenLMState>();
   if (startWithNothing) {
     language_model_->NullContextWrite(outState->ken());
   } else {
@@ -395,32 +443,30 @@ Scorer::start(bool startWithNothing)
   return outState;
 }
 
-std::pair<LMStatePtr, float>
-Scorer::score(const LMStatePtr& state,
-              const int usrTokenIdx)
+pair<LMStatePtr, float>
+Scorer::score(const LMStatePtr& state, const int usrTokenIdx)
 {
   if (usrTokenIdx < 0 || usrTokenIdx >= usrToLmIdxMap_.size()) {
-    throw std::runtime_error(
-        "[Scorer] Invalid user token index: " + std::to_string(usrTokenIdx));
+    throw runtime_error("[Scorer] Invalid user token index: " +
+                        to_string(usrTokenIdx));
   }
-  auto inState = std::static_pointer_cast<KenLMState>(state);
+  auto inState = static_pointer_cast<KenLMState>(state);
   auto outState = inState->child<KenLMState>(usrTokenIdx);
   float score = language_model_->BaseScore(
-      inState->ken(), usrToLmIdxMap_[usrTokenIdx], outState->ken());
-  return std::make_pair(std::move(outState), score);
+    inState->ken(), usrToLmIdxMap_[usrTokenIdx], outState->ken());
+  return make_pair(move(outState), score);
 }
 
-std::pair<LMStatePtr, float>
+pair<LMStatePtr, float>
 Scorer::finish(const LMStatePtr& state)
 {
-  auto inState = std::static_pointer_cast<KenLMState>(state);
+  auto inState = static_pointer_cast<KenLMState>(state);
   auto outState = inState->child<KenLMState>(-1);
-  float score = language_model_->BaseScore(
-                  inState->ken(),
-                  language_model_->BaseVocabulary().EndSentence(),
-                  outState->ken()
-                );
-  return std::make_pair(std::move(outState), score);
+  float score =
+    language_model_->BaseScore(inState->ken(),
+                               language_model_->BaseVocabulary().EndSentence(),
+                               outState->ken());
+  return make_pair(move(outState), score);
 }
 
 void

--- a/native_client/ctcdecode/scorer.h
+++ b/native_client/ctcdecode/scorer.h
@@ -9,9 +9,9 @@
 
 #include "flashlight/lib/text/decoder/lm/KenLM.h"
 
-#include "path_trie.h"
 #include "alphabet.h"
 #include "coqui-stt.h"
+#include "path_trie.h"
 
 const double OOV_SCORE = -1000.0;
 const std::string START_TOKEN = "<s>";
@@ -25,7 +25,8 @@ const std::string END_TOKEN = "</s>";
  *     Scorer scorer(alpha, beta, "path_of_language_model");
  *     scorer.get_log_cond_prob({ "WORD1", "WORD2", "WORD3" });
  */
-class Scorer : public fl::lib::text::LM {
+class Scorer : public fl::lib::text::LM
+{
 public:
   using FstType = PathTrie::FstType;
 
@@ -36,22 +37,25 @@ public:
   Scorer(const Scorer&) = delete;
   Scorer& operator=(const Scorer&) = delete;
 
-  int init(const std::string &lm_path,
-           bool load_from_bytes,
-           const Alphabet &alphabet);
+  int init_from_filepath(const std::string& lm_path, const Alphabet& alphabet);
 
-  int init(const std::string &lm_path,
-           bool load_from_bytes,
-           const std::string &alphabet_config_path);
+  int init_from_filepath(const std::string& lm_path,
+                         const std::string& alphabet_config_path);
 
-  double get_log_cond_prob(const std::vector<std::string> &words,
+  int init_from_buffer(const std::string& buffer, const Alphabet& alphabet);
+
+  int init_from_buffer(const std::string& lm_path,
+                       const std::string& alphabet_config_path);
+
+  double get_log_cond_prob(const std::vector<std::string>& words,
                            bool bos = false,
                            bool eos = false);
 
-  double get_log_cond_prob(const std::vector<std::string>::const_iterator &begin,
-                           const std::vector<std::string>::const_iterator &end,
-                           bool bos = false,
-                           bool eos = false);
+  double get_log_cond_prob(
+    const std::vector<std::string>::const_iterator& begin,
+    const std::vector<std::string>::const_iterator& end,
+    bool bos = false,
+    bool eos = false);
 
   // return the max order
   size_t get_max_order() const { return max_order_; }
@@ -66,25 +70,31 @@ public:
   void set_utf8_mode(bool utf8) { is_utf8_mode_ = utf8; }
 
   // make ngram for a given prefix
-  std::vector<std::string> make_ngram(PathTrie *prefix);
+  std::vector<std::string> make_ngram(PathTrie* prefix);
 
   // trransform the labels in index to the vector of words (word based lm) or
   // the vector of characters (character based lm)
-  std::vector<std::string> split_labels_into_scored_units(const std::vector<unsigned int> &labels);
+  std::vector<std::string> split_labels_into_scored_units(
+    const std::vector<unsigned int>& labels);
 
   void set_alphabet(const Alphabet& alphabet);
 
   // save dictionary in file
-  bool save_dictionary(const std::string &path, bool append_instead_of_overwrite=false);
+  bool save_dictionary(const std::string& path,
+                       bool append_instead_of_overwrite = false);
 
-  // return weather this step represents a boundary where beam scoring should happen
+  // return weather this step represents a boundary where beam scoring should
+  // happen
   bool is_scoring_boundary(PathTrie* prefix, size_t new_label);
 
   // fill dictionary FST from a vocabulary
-  void fill_dictionary(const std::unordered_set<std::string> &vocabulary);
+  void fill_dictionary(const std::unordered_set<std::string>& vocabulary);
 
   // load language model from given path
-  int load_lm(const std::string &lm_path, bool load_from_bytes=false);
+  int load_lm_filepath(const std::string& lm_path);
+
+  // load language model from memory buffer
+  int load_lm_buffer(const std::string& buffer);
 
   // language model weight
   double alpha = 0.;
@@ -105,11 +115,12 @@ public:
    * new language model state and score.
    */
   std::pair<fl::lib::text::LMStatePtr, float> score(
-      const fl::lib::text::LMStatePtr& state,
-      const int usrTokenIdx);
+    const fl::lib::text::LMStatePtr& state,
+    const int usrTokenIdx);
 
   /* Query the language model and finish decoding. */
-  std::pair<fl::lib::text::LMStatePtr, float> finish(const fl::lib::text::LMStatePtr& state);
+  std::pair<fl::lib::text::LMStatePtr, float> finish(
+    const fl::lib::text::LMStatePtr& state);
 
   // ---------------
   // fl::lib::text helper
@@ -121,7 +132,11 @@ protected:
   // necessary setup after setting alphabet
   void setup_char_map();
 
-  int load_trie(std::stringstream& fin, const std::string& file_path, bool load_from_bytes=false);
+  int load_trie_buffer(std::stringstream& stream);
+  int load_trie_mmap(std::ifstream& stream, const std::string& file_path);
+  int load_trie_impl(std::basic_istream<char>& stream,
+                     const std::string& file_path,
+                     bool load_from_bytes);
 
 private:
   std::unique_ptr<lm::base::Model> language_model_;
@@ -133,4 +148,4 @@ private:
   std::unordered_map<std::string, int> char_map_;
 };
 
-#endif  // SCORER_H_
+#endif // SCORER_H_

--- a/native_client/ctcdecode/scorer.h
+++ b/native_client/ctcdecode/scorer.h
@@ -37,9 +37,11 @@ public:
   Scorer& operator=(const Scorer&) = delete;
 
   int init(const std::string &lm_path,
+           bool load_from_bytes,
            const Alphabet &alphabet);
 
   int init(const std::string &lm_path,
+           bool load_from_bytes,
            const std::string &alphabet_config_path);
 
   double get_log_cond_prob(const std::vector<std::string> &words,
@@ -82,7 +84,7 @@ public:
   void fill_dictionary(const std::unordered_set<std::string> &vocabulary);
 
   // load language model from given path
-  int load_lm(const std::string &lm_path);
+  int load_lm(const std::string &lm_path, bool load_from_bytes=false);
 
   // language model weight
   double alpha = 0.;
@@ -119,7 +121,7 @@ protected:
   // necessary setup after setting alphabet
   void setup_char_map();
 
-  int load_trie(std::ifstream& fin, const std::string& file_path);
+  int load_trie(std::stringstream& fin, const std::string& file_path, bool load_from_bytes=false);
 
 private:
   std::unique_ptr<lm::base::Model> language_model_;

--- a/native_client/definitions.mk
+++ b/native_client/definitions.mk
@@ -31,14 +31,7 @@ CXXFLAGS        :=
 LDFLAGS         :=
 SOX_CFLAGS      := -I$(ROOT_DIR)/sox-build/include
 ifeq ($(OS),Linux)
-MAGIC_LINK_LZMA := $(shell objdump -tTC /usr/lib/`uname -m`-linux-gnu/libmagic.so | grep lzma | grep '*UND*' | wc -l)
-ifneq ($(MAGIC_LINK_LZMA),0)
-MAYBE_LINK_LZMA := -llzma
-endif # MAGIC_LINK_LZMA
-MAGIC_LINK_BZ2  := $(shell objdump -tTC /usr/lib/`uname -m`-linux-gnu/libmagic.so | grep BZ2 | grep '*UND*' | wc -l)
-ifneq ($(MAGIC_LINK_BZ2),0)
-MAYBE_LINK_BZ2  := -lbz2
-endif # MAGIC_LINK_BZ2
+LINK_STT := $(LINK_STT) -llzma -lbz2
 SOX_LDFLAGS     := -L$(ROOT_DIR)/sox-build/lib -lsox
 else ifeq ($(OS),Darwin)
 SOX_CFLAGS              := $(shell pkg-config --cflags sox)

--- a/native_client/generate_scorer_package.cpp
+++ b/native_client/generate_scorer_package.cpp
@@ -66,7 +66,7 @@ create_package(absl::optional<string> checkpoint_path,
     }
     scorer.set_utf8_mode(force_bytes_output_mode.value());
     scorer.reset_params(default_alpha, default_beta);
-    int err = scorer.load_lm(lm_path);
+    int err = scorer.load_lm_filepath(lm_path);
     if (err != STT_ERR_SCORER_NO_TRIE) {
         cerr << "Error loading language model file: "
              << (err == STT_ERR_SCORER_UNREADABLE ? "Can't open binary LM file." : STT_ErrorCodeToErrorMessage(err))

--- a/native_client/kenlm/lm/bhiksha.cc
+++ b/native_client/kenlm/lm/bhiksha.cc
@@ -17,9 +17,13 @@ DontBhiksha::DontBhiksha(const void * /*base*/, uint64_t /*max_offset*/, uint64_
 const uint8_t kArrayBhikshaVersion = 0;
 
 // TODO: put this in binary file header instead when I change the binary file format again.
-void ArrayBhiksha::UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config) {
+void ArrayBhiksha::UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config, bool load_from_bytes) {
   uint8_t buffer[2];
-  file.ReadForConfig(buffer, 2, offset);
+  if(load_from_bytes){
+    file.ReadForConfig(buffer, 2, offset, load_from_bytes);
+  } else {
+    file.ReadForConfig(buffer, 2, offset);
+  }
   uint8_t version = buffer[0];
   uint8_t configured_bits = buffer[1];
   if (version != kArrayBhikshaVersion) UTIL_THROW(FormatLoadException, "This file has sorted array compression version " << (unsigned) version << " but the code expects version " << (unsigned)kArrayBhikshaVersion);

--- a/native_client/kenlm/lm/bhiksha.hh
+++ b/native_client/kenlm/lm/bhiksha.hh
@@ -34,6 +34,7 @@ class DontBhiksha {
     static const ModelType kModelTypeAdd = static_cast<ModelType>(0);
 
     static void UpdateConfigFromBinary(const BinaryFormat &, uint64_t, Config &/*config*/) {}
+    static void UpdateConfigFromBinary(const BinaryFormat &, uint64_t, Config &, bool) {}
 
     static uint64_t Size(uint64_t /*max_offset*/, uint64_t /*max_next*/, const Config &/*config*/) { return 0; }
 
@@ -65,7 +66,7 @@ class ArrayBhiksha {
   public:
     static const ModelType kModelTypeAdd = kArrayAdd;
 
-    static void UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config);
+    static void UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config, bool load_from_bytes);
 
     static uint64_t Size(uint64_t max_offset, uint64_t max_next, const Config &config);
 

--- a/native_client/kenlm/lm/binary_format.cc
+++ b/native_client/kenlm/lm/binary_format.cc
@@ -11,6 +11,7 @@
 #include <cstdlib>
 
 #include <stdint.h>
+#include <string>
 
 namespace lm {
 namespace ngram {
@@ -114,6 +115,48 @@ bool IsBinaryFormat(int fd) {
   return false;
 }
 
+bool IsBinaryFormat(char *file_data, uint64_t size) {
+  char *file_data_temp = new char[size];
+  memcpy(file_data_temp,file_data, size);
+
+  if (size == util::kBadSize || (size <= static_cast<uint64_t>(sizeof(Sanity)))) {
+    delete[] file_data_temp;
+    return false;
+  }
+
+  // Try reading the header.
+  util::scoped_memory memory;
+  try {
+    util::MapRead(util::LAZY, file_data_temp, 0, sizeof(Sanity), memory);
+  } catch (const util::Exception &e) {
+    return false;
+  }
+  Sanity reference_header = Sanity();
+  reference_header.SetToReference();
+
+  if (!std::memcmp(memory.get(), &reference_header, sizeof(Sanity))) {
+    return true;
+  }
+  if (!std::memcmp(memory.get(), kMagicIncomplete, strlen(kMagicIncomplete))) {
+    UTIL_THROW(FormatLoadException, "This binary file did not finish building");
+  }
+  if (!std::memcmp(memory.get(), kMagicBeforeVersion, strlen(kMagicBeforeVersion))) {
+    char *end_ptr;
+    const char *begin_version = static_cast<const char*>(memory.get()) + strlen(kMagicBeforeVersion);
+    long int version = std::strtol(begin_version, &end_ptr, 10);
+    if ((end_ptr != begin_version) && version != kMagicVersion) {
+      UTIL_THROW(FormatLoadException, "Binary file has version " << version << " but this implementation expects version " << kMagicVersion << " so you'll have to use the ARPA to rebuild your binary");
+    }
+    OldSanity old_sanity = OldSanity();
+    old_sanity.SetToReference();
+    UTIL_THROW_IF(!std::memcmp(memory.get(), &old_sanity, sizeof(OldSanity)), FormatLoadException, "Looks like this is an old 32-bit format.  The old 32-bit format has been removed so that 64-bit and 32-bit files are exchangeable.");
+    UTIL_THROW(FormatLoadException, "File looks like it should be loaded with mmap, but the test values don't match.  Try rebuilding the binary format LM using the same code revision, compiler, and architecture");
+  }
+  return false;
+}
+
+
+
 void ReadHeader(int fd, Parameters &out) {
   util::SeekOrThrow(fd, sizeof(Sanity));
   util::ReadOrThrow(fd, &out.fixed, sizeof(out.fixed));
@@ -123,6 +166,23 @@ void ReadHeader(int fd, Parameters &out) {
   out.counts.resize(static_cast<std::size_t>(out.fixed.order));
   if (out.fixed.order) util::ReadOrThrow(fd, &*out.counts.begin(), sizeof(uint64_t) * out.fixed.order);
 }
+
+void ReadHeader(char *file_data, Parameters &out) {
+  const char *file_data_tmp = file_data;
+  file_data_tmp += sizeof(Sanity);
+  std::memcpy(&out.fixed, file_data_tmp, sizeof(out.fixed));
+  file_data_tmp += sizeof(out.fixed);
+
+  if (out.fixed.probing_multiplier < 1.0)
+    UTIL_THROW(FormatLoadException, "Binary format claims to have a probing multiplier of " << out.fixed.probing_multiplier << " which is < 1.0.");
+
+  out.counts.resize(static_cast<std::size_t>(out.fixed.order));
+
+  if (out.fixed.order) {
+    std::memcpy(&*out.counts.begin(), file_data_tmp, sizeof(uint64_t) * out.fixed.order);
+  }
+}
+
 
 void MatchCheck(ModelType model_type, unsigned int search_version, const Parameters &params) {
   if (params.fixed.model_type != model_type) {
@@ -147,10 +207,25 @@ void BinaryFormat::InitializeBinary(int fd, ModelType model_type, unsigned int s
   header_size_ = TotalHeaderSize(params.counts.size());
 }
 
+void BinaryFormat::InitializeBinary(char *file_data, ModelType model_type, unsigned int search_version, Parameters &params) {  
+  file_data_ = file_data;
+  write_mmap_ = NULL; // Ignore write requests; this is already in binary format.
+  ReadHeader(file_data, params);
+  MatchCheck(model_type, search_version, params);
+  header_size_ = TotalHeaderSize(params.counts.size());
+}
+
+
 void BinaryFormat::ReadForConfig(void *to, std::size_t amount, uint64_t offset_excluding_header) const {
   assert(header_size_ != kInvalidSize);
   util::ErsatzPRead(file_.get(), to, amount, offset_excluding_header + header_size_);
 }
+
+void BinaryFormat::ReadForConfig(void *to, std::size_t amount, uint64_t offset_excluding_header, bool load_from_memory) const {
+  assert(header_size_ != kInvalidSize);
+  util::ErsatzPRead(file_data_, to, amount, offset_excluding_header + header_size_);
+}
+
 
 void *BinaryFormat::LoadBinary(std::size_t size) {
   assert(header_size_ != kInvalidSize);
@@ -164,6 +239,17 @@ void *BinaryFormat::LoadBinary(std::size_t size) {
   vocab_string_offset_ = total_map;
   return reinterpret_cast<uint8_t*>(mapping_.get()) + header_size_;
 }
+
+void *BinaryFormat::LoadBinary(std::size_t size, const uint64_t file_size) { /* Loading the binary from memory */
+  assert(header_size_ != kInvalidSize);
+  // The header is smaller than a page, so we have to map the whole header as well.
+  uint64_t total_map = static_cast<uint64_t>(header_size_) + static_cast<uint64_t>(size);
+  UTIL_THROW_IF(file_size != util::kBadSize && file_size < total_map, FormatLoadException, "Binary file has size " << file_size << " but the headers say it should be at least " << total_map);
+  util::MapRead(load_method_, file_data_, 0, util::CheckOverflow(total_map), mapping_);
+  vocab_string_offset_ = total_map;
+  return reinterpret_cast<uint8_t*>(mapping_.get()) + header_size_;
+}
+
 
 void *BinaryFormat::SetupJustVocab(std::size_t memory_size, uint8_t order) {
   vocab_size_ = memory_size;
@@ -282,7 +368,7 @@ void BinaryFormat::FinishFile(const Config &config, ModelType model_type, unsign
 }
 
 void BinaryFormat::MapFile(void *&vocab_base, void *&search_base) {
-  mapping_.reset(util::MapOrThrow(vocab_string_offset_, true, util::kFileFlags, false, file_.get()), vocab_string_offset_, util::scoped_memory::MMAP_ALLOCATED);
+  mapping_.reset(util::MapOrThrow(vocab_string_offset_, true, util::kFileFlags, false, (int) file_.get()), vocab_string_offset_, util::scoped_memory::MMAP_ALLOCATED);
   vocab_base = reinterpret_cast<uint8_t*>(mapping_.get()) + header_size_;
   search_base = reinterpret_cast<uint8_t*>(mapping_.get()) + header_size_ + vocab_size_ + vocab_pad_;
 }
@@ -297,6 +383,22 @@ bool RecognizeBinary(const char *file, ModelType &recognized) {
   recognized = params.fixed.model_type;
   return true;
 }
+
+bool RecognizeBinary(const char *file_data, const uint64_t file_data_size, ModelType &recognized) {
+  
+  char *file_data_temp = new char[file_data_size];
+  memcpy(file_data_temp, file_data, file_data_size);
+  
+  if (!IsBinaryFormat(file_data_temp, file_data_size)){
+    return false;
+  }
+
+  Parameters params;
+  ReadHeader(file_data_temp, params);
+  recognized = params.fixed.model_type;
+  return true;
+}
+
 
 } // namespace ngram
 } // namespace lm

--- a/native_client/kenlm/lm/binary_format.hh
+++ b/native_client/kenlm/lm/binary_format.hh
@@ -56,7 +56,7 @@ class BinaryFormat {
     // Reading a binary file:
     // Takes ownership of fd
     void InitializeBinary(int fd, ModelType model_type, unsigned int search_version, Parameters &params);
-    void InitializeBinary(char *file_data, ModelType model_type, unsigned int search_version, Parameters &params);
+    void InitializeBinary(const char *file_data, ModelType model_type, unsigned int search_version, Parameters &params);
     // Used to read parts of the file to update the config object before figuring out full size.
     void ReadForConfig(void *to, std::size_t amount, uint64_t offset_excluding_header) const;
     void ReadForConfig(void *to, std::size_t amount, uint64_t offset_excluding_header, bool useMemory) const;
@@ -89,7 +89,7 @@ class BinaryFormat {
 
     // File behind memory, if any.
     util::scoped_fd file_;
-    char *file_data_;
+    const char *file_data_;
 
     // If there is a file involved, a single mapping.
     util::scoped_memory mapping_= new util::scoped_memory(true);
@@ -109,7 +109,7 @@ class BinaryFormat {
 };
 
 bool IsBinaryFormat(int fd);
-bool IsBinaryFormat(char *file_data, uint64_t size);
+bool IsBinaryFormat(const char *file_data, uint64_t size);
 
 } // namespace ngram
 } // namespace lm

--- a/native_client/kenlm/lm/binary_format.hh
+++ b/native_client/kenlm/lm/binary_format.hh
@@ -24,6 +24,7 @@ extern const char *kModelNames[6];
  * this header designed for use by decoder authors.
  */
 KENLM_EXPORT bool RecognizeBinary(const char *file, ModelType &recognized);
+KENLM_EXPORT bool RecognizeBinary(const char *file_data, const uint64_t file_data_size, ModelType &recognized);
 
 struct FixedWidthParameters {
   unsigned char order;
@@ -48,13 +49,20 @@ class BinaryFormat {
   public:
     explicit BinaryFormat(const Config &config);
 
+    ~BinaryFormat(){
+      file_data_ = NULL;
+    }
+
     // Reading a binary file:
     // Takes ownership of fd
     void InitializeBinary(int fd, ModelType model_type, unsigned int search_version, Parameters &params);
+    void InitializeBinary(char *file_data, ModelType model_type, unsigned int search_version, Parameters &params);
     // Used to read parts of the file to update the config object before figuring out full size.
     void ReadForConfig(void *to, std::size_t amount, uint64_t offset_excluding_header) const;
+    void ReadForConfig(void *to, std::size_t amount, uint64_t offset_excluding_header, bool useMemory) const;
     // Actually load the binary file and return a pointer to the beginning of the search area.
     void *LoadBinary(std::size_t size);
+    void *LoadBinary(std::size_t size, const uint64_t  file_size);
 
     uint64_t VocabStringReadingOffset() const {
       assert(vocab_string_offset_ != kInvalidOffset);
@@ -81,9 +89,10 @@ class BinaryFormat {
 
     // File behind memory, if any.
     util::scoped_fd file_;
+    char *file_data_;
 
     // If there is a file involved, a single mapping.
-    util::scoped_memory mapping_;
+    util::scoped_memory mapping_= new util::scoped_memory(true);
 
     // If the data is only in memory, separately allocate each because the trie
     // knows vocab's size before it knows search's size (because SRILM might
@@ -100,6 +109,7 @@ class BinaryFormat {
 };
 
 bool IsBinaryFormat(int fd);
+bool IsBinaryFormat(char *file_data, uint64_t size);
 
 } // namespace ngram
 } // namespace lm

--- a/native_client/kenlm/lm/model.cc
+++ b/native_client/kenlm/lm/model.cc
@@ -66,7 +66,7 @@ template <class Search, class VocabularyT> GenericModel<Search, VocabularyT>::Ge
 
     Config new_config(init_config);
     new_config.probing_multiplier = parameters.fixed.probing_multiplier;
-    Search::UpdateConfigFromBinary(backing_, parameters.counts, VocabularyT::Size(parameters.counts[0], new_config), new_config);
+    Search::UpdateConfigFromBinary(backing_, parameters.counts, VocabularyT::Size(parameters.counts[0], new_config), new_config, false);
     UTIL_THROW_IF(new_config.enumerate_vocab && !parameters.fixed.has_vocabulary, FormatLoadException, "The decoder requested all the vocabulary strings, but this binary file does not have them.  You may need to rebuild the binary file with an updated version of build_binary.");
 
     SetupMemory(backing_.LoadBinary(Size(parameters.counts, new_config)), parameters.counts, new_config);
@@ -88,6 +88,48 @@ template <class Search, class VocabularyT> GenericModel<Search, VocabularyT>::Ge
   null_context.length = 0;
   P::Init(begin_sentence, null_context, vocab_, search_.Order());
 }
+
+template <class Search, class VocabularyT> GenericModel<Search, VocabularyT>::GenericModel(const char *file_data, const uint64_t file_data_size, const Config &init_config) : backing_(init_config) { 
+  char *file_data_temp = new char[file_data_size];
+  memcpy(file_data_temp, file_data, file_data_size);
+
+  if (IsBinaryFormat(file_data_temp, file_data_size)) {
+    Parameters parameters;
+    backing_.InitializeBinary(file_data_temp, kModelType, kVersion, parameters);
+    CheckCounts(parameters.counts);
+
+    Config new_config(init_config);
+    new_config.probing_multiplier = parameters.fixed.probing_multiplier;
+    Search::UpdateConfigFromBinary(backing_, parameters.counts, VocabularyT::Size(parameters.counts[0], new_config), new_config, true);
+    
+    UTIL_THROW_IF(new_config.enumerate_vocab && !parameters.fixed.has_vocabulary, FormatLoadException, "The decoder requested all the vocabulary strings, but this binary file does not have them.  You may need to rebuild the binary file with an updated version of build_binary.");
+    
+    SetupMemory(backing_.LoadBinary(Size(parameters.counts, new_config), file_data_size), parameters.counts, new_config);
+
+    vocab_.LoadedBinary(parameters.fixed.has_vocabulary, file_data_temp, new_config.enumerate_vocab, backing_.VocabStringReadingOffset(), true);
+    
+    delete[] file_data_temp;    
+  } else {
+    std::cerr << "Fatal error: Not binary!" << std::endl;
+    delete[] file_data_temp;
+    return;
+  }
+  // g++ prints warnings unless these are fully initialized.
+  State begin_sentence = State();
+
+  begin_sentence.length = 1;
+  begin_sentence.words[0] = vocab_.BeginSentence();
+  typename Search::Node ignored_node;
+  bool ignored_independent_left;
+  uint64_t ignored_extend_left;
+
+  begin_sentence.backoff[0] = search_.LookupUnigram(begin_sentence.words[0], ignored_node, ignored_independent_left, ignored_extend_left).Backoff();
+
+  State null_context = State();
+  null_context.length = 0;
+  P::Init(begin_sentence, null_context, vocab_, search_.Order());
+}
+
 
 template <class Search, class VocabularyT> void GenericModel<Search, VocabularyT>::InitializeFromARPA(int fd, const char *file, const Config &config) {
   // Backing file is the ARPA.
@@ -348,6 +390,26 @@ base::Model *LoadVirtual(const char *file_name, const Config &config, ModelType 
       UTIL_THROW(FormatLoadException, "Confused by model type " << model_type);
   }
 }
+base::Model *LoadVirtual(const char *file_data, const uint64_t file_data_size, const Config &config, ModelType model_type) {
+  RecognizeBinary(file_data, file_data_size, model_type);
+  switch (model_type) {
+    case PROBING:
+      UTIL_THROW(FormatLoadException, "Probing without memory option " << model_type);
+    case REST_PROBING:
+      UTIL_THROW(FormatLoadException, "Rest Probing without memory option " << model_type);
+    case TRIE:
+      UTIL_THROW(FormatLoadException, "Trie without memory option " << model_type);
+    case QUANT_TRIE:
+      UTIL_THROW(FormatLoadException, "Quant Trie without memory option " << model_type);
+    case ARRAY_TRIE:
+      UTIL_THROW(FormatLoadException, "Array Trie without memory option " << model_type);
+    case QUANT_ARRAY_TRIE:
+      return new QuantArrayTrieModelMemory(file_data, file_data_size, config);
+    default:
+      UTIL_THROW(FormatLoadException, "Confused by model type " << model_type);
+  }
+}
+
 
 } // namespace ngram
 } // namespace lm

--- a/native_client/kenlm/lm/model.cc
+++ b/native_client/kenlm/lm/model.cc
@@ -89,29 +89,24 @@ template <class Search, class VocabularyT> GenericModel<Search, VocabularyT>::Ge
   P::Init(begin_sentence, null_context, vocab_, search_.Order());
 }
 
-template <class Search, class VocabularyT> GenericModel<Search, VocabularyT>::GenericModel(const char *file_data, const uint64_t file_data_size, const Config &init_config) : backing_(init_config) { 
-  char *file_data_temp = new char[file_data_size];
-  memcpy(file_data_temp, file_data, file_data_size);
-
-  if (IsBinaryFormat(file_data_temp, file_data_size)) {
+template <class Search, class VocabularyT>
+GenericModel<Search, VocabularyT>::GenericModel(const char *file_data, const uint64_t file_data_size, const Config &init_config) : backing_(init_config) {
+  if (IsBinaryFormat(file_data, file_data_size)) {
     Parameters parameters;
-    backing_.InitializeBinary(file_data_temp, kModelType, kVersion, parameters);
+    backing_.InitializeBinary(file_data, kModelType, kVersion, parameters);
     CheckCounts(parameters.counts);
 
     Config new_config(init_config);
     new_config.probing_multiplier = parameters.fixed.probing_multiplier;
     Search::UpdateConfigFromBinary(backing_, parameters.counts, VocabularyT::Size(parameters.counts[0], new_config), new_config, true);
-    
+
     UTIL_THROW_IF(new_config.enumerate_vocab && !parameters.fixed.has_vocabulary, FormatLoadException, "The decoder requested all the vocabulary strings, but this binary file does not have them.  You may need to rebuild the binary file with an updated version of build_binary.");
-    
+
     SetupMemory(backing_.LoadBinary(Size(parameters.counts, new_config), file_data_size), parameters.counts, new_config);
 
-    vocab_.LoadedBinary(parameters.fixed.has_vocabulary, file_data_temp, new_config.enumerate_vocab, backing_.VocabStringReadingOffset(), true);
-    
-    delete[] file_data_temp;    
+    vocab_.LoadedBinary(parameters.fixed.has_vocabulary, file_data, new_config.enumerate_vocab, backing_.VocabStringReadingOffset(), true);
   } else {
     std::cerr << "Fatal error: Not binary!" << std::endl;
-    delete[] file_data_temp;
     return;
   }
   // g++ prints warnings unless these are fully initialized.
@@ -394,17 +389,17 @@ base::Model *LoadVirtual(const char *file_data, const uint64_t file_data_size, c
   RecognizeBinary(file_data, file_data_size, model_type);
   switch (model_type) {
     case PROBING:
-      UTIL_THROW(FormatLoadException, "Probing without memory option " << model_type);
+      return new ProbingModel(file_data, file_data_size, config);
     case REST_PROBING:
-      UTIL_THROW(FormatLoadException, "Rest Probing without memory option " << model_type);
+      return new RestProbingModel(file_data, file_data_size, config);
     case TRIE:
-      UTIL_THROW(FormatLoadException, "Trie without memory option " << model_type);
+      return new TrieModel(file_data, file_data_size, config);
     case QUANT_TRIE:
-      UTIL_THROW(FormatLoadException, "Quant Trie without memory option " << model_type);
+      return new QuantTrieModel(file_data, file_data_size, config);
     case ARRAY_TRIE:
-      UTIL_THROW(FormatLoadException, "Array Trie without memory option " << model_type);
+      return new ArrayTrieModel(file_data, file_data_size, config);
     case QUANT_ARRAY_TRIE:
-      return new QuantArrayTrieModelMemory(file_data, file_data_size, config);
+      return new QuantArrayTrieModel(file_data, file_data_size, config);
     default:
       UTIL_THROW(FormatLoadException, "Confused by model type " << model_type);
   }

--- a/native_client/kenlm/lm/model.hh
+++ b/native_client/kenlm/lm/model.hh
@@ -49,7 +49,7 @@ template <class Search, class VocabularyT> class GenericModel : public base::Mod
      * lm/binary_format.hh.
      */
     explicit GenericModel(const char *file, const Config &config = Config());
-
+    explicit GenericModel(const char *file_data, const uint64_t file_data_size, const Config &config = Config());
     /* Score p(new_word | in_state) and incorporate new_word into out_state.
      * Note that in_state and out_state must be different references:
      * &in_state != &out_state.
@@ -133,7 +133,15 @@ template <class Search, class VocabularyT> class GenericModel : public base::Mod
 class name : public from {\
   public:\
     name(const char *file, const Config &config = Config()) : from(file, config) {}\
+  };
+  
+#define LM_NAME_MODEL_FROM_MEMORY(name, from)\
+class name : public from {\
+  public:\
+    name(const char *file, const Config &config = Config()) : from(file, config) {}\
+    name(const char *file_data, size_t file_data_size, const Config &config = Config()) : from(file_data, file_data_size, config) {}\
 };
+
 
 LM_NAME_MODEL(ProbingModel, detail::GenericModel<detail::HashedSearch<BackoffValue> LM_COMMA() ProbingVocabulary>);
 LM_NAME_MODEL(RestProbingModel, detail::GenericModel<detail::HashedSearch<RestValue> LM_COMMA() ProbingVocabulary>);
@@ -141,15 +149,17 @@ LM_NAME_MODEL(TrieModel, detail::GenericModel<trie::TrieSearch<DontQuantize LM_C
 LM_NAME_MODEL(ArrayTrieModel, detail::GenericModel<trie::TrieSearch<DontQuantize LM_COMMA() trie::ArrayBhiksha> LM_COMMA() SortedVocabulary>);
 LM_NAME_MODEL(QuantTrieModel, detail::GenericModel<trie::TrieSearch<SeparatelyQuantize LM_COMMA() trie::DontBhiksha> LM_COMMA() SortedVocabulary>);
 LM_NAME_MODEL(QuantArrayTrieModel, detail::GenericModel<trie::TrieSearch<SeparatelyQuantize LM_COMMA() trie::ArrayBhiksha> LM_COMMA() SortedVocabulary>);
+LM_NAME_MODEL_FROM_MEMORY(QuantArrayTrieModelMemory, detail::GenericModel<trie::TrieSearch<SeparatelyQuantize LM_COMMA() trie::ArrayBhiksha> LM_COMMA() SortedVocabulary>);
 
 // Default implementation.  No real reason for it to be the default.
 typedef ::lm::ngram::ProbingVocabulary Vocabulary;
 typedef ProbingModel Model;
-
+typedef QuantArrayTrieModelMemory ModelMemory;
 /* Autorecognize the file type, load, and return the virtual base class.  Don't
  * use the virtual base class if you can avoid it.  Instead, use the above
  * classes as template arguments to your own virtual feature function.*/
 KENLM_EXPORT base::Model *LoadVirtual(const char *file_name, const Config &config = Config(), ModelType if_arpa = PROBING);
+KENLM_EXPORT base::Model *LoadVirtual(const char *file_data, const uint64_t file_data_size, const Config &config = Config(), ModelType if_arpa = PROBING);
 
 } // namespace ngram
 } // namespace lm

--- a/native_client/kenlm/lm/model.hh
+++ b/native_client/kenlm/lm/model.hh
@@ -133,14 +133,8 @@ template <class Search, class VocabularyT> class GenericModel : public base::Mod
 class name : public from {\
   public:\
     name(const char *file, const Config &config = Config()) : from(file, config) {}\
-  };
-  
-#define LM_NAME_MODEL_FROM_MEMORY(name, from)\
-class name : public from {\
-  public:\
-    name(const char *file, const Config &config = Config()) : from(file, config) {}\
     name(const char *file_data, size_t file_data_size, const Config &config = Config()) : from(file_data, file_data_size, config) {}\
-};
+  };
 
 
 LM_NAME_MODEL(ProbingModel, detail::GenericModel<detail::HashedSearch<BackoffValue> LM_COMMA() ProbingVocabulary>);
@@ -149,12 +143,10 @@ LM_NAME_MODEL(TrieModel, detail::GenericModel<trie::TrieSearch<DontQuantize LM_C
 LM_NAME_MODEL(ArrayTrieModel, detail::GenericModel<trie::TrieSearch<DontQuantize LM_COMMA() trie::ArrayBhiksha> LM_COMMA() SortedVocabulary>);
 LM_NAME_MODEL(QuantTrieModel, detail::GenericModel<trie::TrieSearch<SeparatelyQuantize LM_COMMA() trie::DontBhiksha> LM_COMMA() SortedVocabulary>);
 LM_NAME_MODEL(QuantArrayTrieModel, detail::GenericModel<trie::TrieSearch<SeparatelyQuantize LM_COMMA() trie::ArrayBhiksha> LM_COMMA() SortedVocabulary>);
-LM_NAME_MODEL_FROM_MEMORY(QuantArrayTrieModelMemory, detail::GenericModel<trie::TrieSearch<SeparatelyQuantize LM_COMMA() trie::ArrayBhiksha> LM_COMMA() SortedVocabulary>);
 
 // Default implementation.  No real reason for it to be the default.
 typedef ::lm::ngram::ProbingVocabulary Vocabulary;
 typedef ProbingModel Model;
-typedef QuantArrayTrieModelMemory ModelMemory;
 /* Autorecognize the file type, load, and return the virtual base class.  Don't
  * use the virtual base class if you can avoid it.  Instead, use the above
  * classes as template arguments to your own virtual feature function.*/

--- a/native_client/kenlm/lm/quantize.cc
+++ b/native_client/kenlm/lm/quantize.cc
@@ -38,9 +38,15 @@ const char kSeparatelyQuantizeVersion = 2;
 
 } // namespace
 
-void SeparatelyQuantize::UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config) {
+void SeparatelyQuantize::UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config, bool load_from_memory) {
   unsigned char buffer[3];
-  file.ReadForConfig(buffer, 3, offset);
+  if(load_from_memory){
+    file.ReadForConfig(buffer, 3, offset, load_from_memory);
+  }else{
+    file.ReadForConfig(buffer, 3, offset);
+  }
+  std::string strBuffer((char*)buffer,3);
+
   char version = buffer[0];
   config.prob_bits = buffer[1];
   config.backoff_bits = buffer[2];

--- a/native_client/kenlm/lm/quantize.hh
+++ b/native_client/kenlm/lm/quantize.hh
@@ -24,7 +24,7 @@ class BinaryFormat;
 class DontQuantize {
   public:
     static const ModelType kModelTypeAdd = static_cast<ModelType>(0);
-    static void UpdateConfigFromBinary(const BinaryFormat &, uint64_t, Config &) {}
+    static void UpdateConfigFromBinary(const BinaryFormat &, uint64_t, Config &, bool) {}
     static uint64_t Size(uint8_t /*order*/, const Config &/*config*/) { return 0; }
     static uint8_t MiddleBits(const Config &/*config*/) { return 63; }
     static uint8_t LongestBits(const Config &/*config*/) { return 31; }
@@ -137,7 +137,7 @@ class SeparatelyQuantize {
   public:
     static const ModelType kModelTypeAdd = kQuantAdd;
 
-    static void UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config);
+    static void UpdateConfigFromBinary(const BinaryFormat &file, uint64_t offset, Config &config, bool load_from_memory);
 
     static uint64_t Size(uint8_t order, const Config &config) {
       uint64_t longest_table = (static_cast<uint64_t>(1) << static_cast<uint64_t>(config.prob_bits)) * sizeof(float);

--- a/native_client/kenlm/lm/search_hashed.hh
+++ b/native_client/kenlm/lm/search_hashed.hh
@@ -72,7 +72,7 @@ template <class Value> class HashedSearch {
     static const unsigned int kVersion = 0;
 
     // TODO: move probing_multiplier here with next binary file format update.
-    static void UpdateConfigFromBinary(const BinaryFormat &, const std::vector<uint64_t> &, uint64_t, Config &) {}
+    static void UpdateConfigFromBinary(const BinaryFormat &, const std::vector<uint64_t> &, uint64_t, Config &, bool) {}
 
     static uint64_t Size(const std::vector<uint64_t> &counts, const Config &config) {
       uint64_t ret = Unigram::Size(counts[0]);

--- a/native_client/kenlm/lm/search_trie.hh
+++ b/native_client/kenlm/lm/search_trie.hh
@@ -38,11 +38,12 @@ template <class Quant, class Bhiksha> class TrieSearch {
 
     static const unsigned int kVersion = 1;
 
-    static void UpdateConfigFromBinary(const BinaryFormat &file, const std::vector<uint64_t> &counts, uint64_t offset, Config &config) {
-      Quant::UpdateConfigFromBinary(file, offset, config);
+    static void UpdateConfigFromBinary(const BinaryFormat &file, const std::vector<uint64_t> &counts, uint64_t offset, Config &config, bool load_from_memory) {
+      Quant::UpdateConfigFromBinary(file, offset, config, load_from_memory);
+
       // Currently the unigram pointers are not compresssed, so there will only be a header for order > 2.
       if (counts.size() > 2)
-        Bhiksha::UpdateConfigFromBinary(file, offset + Quant::Size(counts.size(), config) + Unigram::Size(counts[0]), config);
+        Bhiksha::UpdateConfigFromBinary(file, offset + Quant::Size(counts.size(), config) + Unigram::Size(counts[0]), config, load_from_memory);
     }
 
     static uint64_t Size(const std::vector<uint64_t> &counts, const Config &config) {

--- a/native_client/kenlm/lm/vocab.cc
+++ b/native_client/kenlm/lm/vocab.cc
@@ -14,6 +14,7 @@
 
 #include <cstring>
 #include <string>
+#include <sstream>
 
 namespace lm {
 namespace ngram {
@@ -51,6 +52,36 @@ void ReadWords(int fd, EnumerateVocab *enumerate, WordIndex expected_count, uint
   }
   UTIL_THROW_IF(expected_count != index, FormatLoadException, "The binary file has the wrong number of words at the end.  This could be caused by a truncated binary file.");
 }
+void ReadWords(char* file_data, EnumerateVocab *enumerate, WordIndex expected_count, uint64_t offset) {  
+  const char *file_data_tmp = file_data;
+  file_data_tmp += offset;
+
+  // Check that we're at the right place by reading <unk> which is always first.
+  char check_unk[6];
+  std::memcpy(check_unk, file_data_tmp, 6);
+  file_data_tmp += 6;
+
+  UTIL_THROW_IF(
+      memcmp(check_unk, "<unk>", 6),
+      FormatLoadException,
+      "Vocabulary words are in the wrong place.  This could be because the binary file was built with stale gcc and old kenlm.  Stale gcc, including the gcc distributed with RedHat and OS X, has a bug that ignores pragma pack for template-dependent types.  New kenlm works around this, so you'll save memory but have to rebuild any binary files using the probing data structure.");
+  if (!enumerate) {
+    return;
+  }
+  enumerate->Add(0, "<unk>");
+
+  WordIndex index = 1; // Read <unk> already.
+  std::istringstream in(file_data_tmp);
+
+  for (std::string line; std::getline(in, line); )
+  {
+    // std::cerr << "LINHA -> " << line << std::endl;
+    enumerate->Add(index, line);
+  }
+
+  UTIL_THROW_IF(expected_count != index, FormatLoadException, "The binary file has the wrong number of words at the end.  This could be caused by a truncated binary file.");
+}
+
 
 // Constructor ordering madness.
 int SeekAndReturn(int fd, uint64_t start) {
@@ -192,6 +223,16 @@ void SortedVocabulary::LoadedBinary(bool have_words, int fd, EnumerateVocab *to,
   if (have_words) ReadWords(fd, to, bound_, offset);
 }
 
+void SortedVocabulary::LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset,  bool load_from_memory) {
+  end_ = begin_ + *(reinterpret_cast<const uint64_t*>(begin_) - 1);
+  SetSpecial(Index("<s>"), Index("</s>"), 0);
+  bound_ = end_ - begin_ + 1;
+  if (have_words) {
+     ReadWords(file_data, to, bound_, offset);
+  }
+}
+
+
 template <class T> void SortedVocabulary::GenericFinished(T *reorder) {
   if (enumerate_) {
     if (!strings_to_enumerate_.empty()) {
@@ -281,6 +322,17 @@ void ProbingVocabulary::LoadedBinary(bool have_words, int fd, EnumerateVocab *to
   SetSpecial(Index("<s>"), Index("</s>"), 0);
   if (have_words) ReadWords(fd, to, bound_, offset);
 }
+
+void ProbingVocabulary::LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory) {
+  UTIL_THROW_IF(header_->version != kProbingVocabularyVersion, FormatLoadException, "The binary file has probing version " << header_->version << " but the code expects version " << kProbingVocabularyVersion << ".  Please rerun build_binary using the same version of the code.");
+  bound_ = header_->bound;
+
+  SetSpecial(Index("<s>"), Index("</s>"), 0);
+  if (have_words) {
+    ReadWords(file_data, to, bound_, offset);
+  }
+}
+
 
 void MissingUnknown(const Config &config) {
   switch(config.unknown_missing) {

--- a/native_client/kenlm/lm/vocab.cc
+++ b/native_client/kenlm/lm/vocab.cc
@@ -52,14 +52,14 @@ void ReadWords(int fd, EnumerateVocab *enumerate, WordIndex expected_count, uint
   }
   UTIL_THROW_IF(expected_count != index, FormatLoadException, "The binary file has the wrong number of words at the end.  This could be caused by a truncated binary file.");
 }
-void ReadWords(char* file_data, EnumerateVocab *enumerate, WordIndex expected_count, uint64_t offset) {  
-  const char *file_data_tmp = file_data;
-  file_data_tmp += offset;
+
+void ReadWords(const char* file_data, EnumerateVocab *enumerate, WordIndex expected_count, uint64_t offset) {
+  file_data += offset;
 
   // Check that we're at the right place by reading <unk> which is always first.
   char check_unk[6];
-  std::memcpy(check_unk, file_data_tmp, 6);
-  file_data_tmp += 6;
+  std::memcpy(check_unk, file_data, 6);
+  file_data += 6;
 
   UTIL_THROW_IF(
       memcmp(check_unk, "<unk>", 6),
@@ -71,11 +71,10 @@ void ReadWords(char* file_data, EnumerateVocab *enumerate, WordIndex expected_co
   enumerate->Add(0, "<unk>");
 
   WordIndex index = 1; // Read <unk> already.
-  std::istringstream in(file_data_tmp);
+  std::istringstream in(file_data);
 
   for (std::string line; std::getline(in, line); )
   {
-    // std::cerr << "LINHA -> " << line << std::endl;
     enumerate->Add(index, line);
   }
 
@@ -223,7 +222,7 @@ void SortedVocabulary::LoadedBinary(bool have_words, int fd, EnumerateVocab *to,
   if (have_words) ReadWords(fd, to, bound_, offset);
 }
 
-void SortedVocabulary::LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset,  bool load_from_memory) {
+void SortedVocabulary::LoadedBinary(bool have_words, const char* file_data, EnumerateVocab *to, uint64_t offset,  bool load_from_memory) {
   end_ = begin_ + *(reinterpret_cast<const uint64_t*>(begin_) - 1);
   SetSpecial(Index("<s>"), Index("</s>"), 0);
   bound_ = end_ - begin_ + 1;
@@ -323,7 +322,7 @@ void ProbingVocabulary::LoadedBinary(bool have_words, int fd, EnumerateVocab *to
   if (have_words) ReadWords(fd, to, bound_, offset);
 }
 
-void ProbingVocabulary::LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory) {
+void ProbingVocabulary::LoadedBinary(bool have_words, const char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory) {
   UTIL_THROW_IF(header_->version != kProbingVocabularyVersion, FormatLoadException, "The binary file has probing version " << header_->version << " but the code expects version " << kProbingVocabularyVersion << ".  Please rerun build_binary using the same version of the code.");
   bound_ = header_->bound;
 

--- a/native_client/kenlm/lm/vocab.hh
+++ b/native_client/kenlm/lm/vocab.hh
@@ -14,6 +14,7 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include <iostream> 
 
 namespace lm {
 struct ProbBackoff;
@@ -111,6 +112,7 @@ class SortedVocabulary : public base::Vocabulary {
     bool SawUnk() const { return saw_unk_; }
 
     void LoadedBinary(bool have_words, int fd, EnumerateVocab *to, uint64_t offset);
+    void LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory);
 
     uint64_t *&EndHack() { return end_; }
 
@@ -190,6 +192,7 @@ class ProbingVocabulary : public base::Vocabulary {
     bool SawUnk() const { return saw_unk_; }
 
     void LoadedBinary(bool have_words, int fd, EnumerateVocab *to, uint64_t offset);
+    void LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory);
 
   private:
     void InternalFinishedLoading();

--- a/native_client/kenlm/lm/vocab.hh
+++ b/native_client/kenlm/lm/vocab.hh
@@ -112,7 +112,7 @@ class SortedVocabulary : public base::Vocabulary {
     bool SawUnk() const { return saw_unk_; }
 
     void LoadedBinary(bool have_words, int fd, EnumerateVocab *to, uint64_t offset);
-    void LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory);
+    void LoadedBinary(bool have_words, const char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory);
 
     uint64_t *&EndHack() { return end_; }
 
@@ -192,7 +192,7 @@ class ProbingVocabulary : public base::Vocabulary {
     bool SawUnk() const { return saw_unk_; }
 
     void LoadedBinary(bool have_words, int fd, EnumerateVocab *to, uint64_t offset);
-    void LoadedBinary(bool have_words, char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory);
+    void LoadedBinary(bool have_words, const char* file_data, EnumerateVocab *to, uint64_t offset, bool load_from_memory);
 
   private:
     void InternalFinishedLoading();

--- a/native_client/kenlm/util/file.cc
+++ b/native_client/kenlm/util/file.cc
@@ -236,7 +236,7 @@ void WriteOrThrow(FILE *to, const void *data, std::size_t size) {
   UTIL_THROW_IF(1 != std::fwrite(data, size, 1, to), ErrnoException, "Short write; requested size " << size);
 }
 
-void ErsatzPRead(char *file_data, void *to_void, std::size_t size, uint64_t off) {
+void ErsatzPRead(const char *file_data, void *to_void, std::size_t size, uint64_t off) {
   uint8_t *to = static_cast<uint8_t*>(to_void);
   while (size) {
     errno = 0;

--- a/native_client/kenlm/util/file.cc
+++ b/native_client/kenlm/util/file.cc
@@ -239,33 +239,16 @@ void WriteOrThrow(FILE *to, const void *data, std::size_t size) {
 void ErsatzPRead(char *file_data, void *to_void, std::size_t size, uint64_t off) {
   uint8_t *to = static_cast<uint8_t*>(to_void);
   while (size) {
-#if defined(_WIN32) || defined(_WIN64)
-    /* BROKEN: changes file pointer.  Even if you save it and change it back, it won't be safe to use concurrently with write() or read() which lmplz does. */
-    // size_t might be 64-bit.  DWORD is always 32.
-    DWORD reading = static_cast<DWORD>(std::min<std::size_t>(kMaxDWORD, size));
-    DWORD ret;
-    OVERLAPPED overlapped;
-    memset(&overlapped, 0, sizeof(OVERLAPPED));
-    overlapped.Offset = static_cast<DWORD>(off);
-    overlapped.OffsetHigh = static_cast<DWORD>(off >> 32);
-    UTIL_THROW_IF(!ReadFile((HANDLE)_get_osfhandle(fd), to, reading, &ret, &overlapped), WindowsException, "ReadFile failed for offset " << off);
-#else
-    ssize_t ret;
     errno = 0;
-    ret = GuardLarge(size);
+    size_t ret = GuardLarge(size);
 
     file_data += off;
-    #if defined(_WIN32) || defined(_WIN64)
-      CopyMemory(out.get(), file_data, size);
-    #else
-      std::memcpy(to, file_data, GuardLarge(size));
-    #endif
+    std::memcpy(to, file_data, GuardLarge(size));
 
     if (ret <= 0) {
       if (ret == -1 && errno == EINTR) continue;
       UTIL_THROW_IF(ret == 0, EndOfFileException, " for reading " << size << " bytes at " << off << " from buffer");
     }
-#endif
     size -= ret;
     off += ret;
     to += ret;

--- a/native_client/kenlm/util/file.hh
+++ b/native_client/kenlm/util/file.hh
@@ -141,7 +141,7 @@ void WriteOrThrow(FILE *to, const void *data, std::size_t size);
  * above.
  */
 void ErsatzPRead(int fd, void *to, std::size_t size, uint64_t off);
-void ErsatzPRead(char *file_data, void *to_void, std::size_t size, uint64_t off);
+void ErsatzPRead(const char *file_data, void *to_void, std::size_t size, uint64_t off);
 void ErsatzPWrite(int fd, const void *data_void, std::size_t size, uint64_t off);
 
 void FSyncOrThrow(int fd);

--- a/native_client/kenlm/util/file.hh
+++ b/native_client/kenlm/util/file.hh
@@ -141,6 +141,7 @@ void WriteOrThrow(FILE *to, const void *data, std::size_t size);
  * above.
  */
 void ErsatzPRead(int fd, void *to, std::size_t size, uint64_t off);
+void ErsatzPRead(char *file_data, void *to_void, std::size_t size, uint64_t off);
 void ErsatzPWrite(int fd, const void *data_void, std::size_t size, uint64_t off);
 
 void FSyncOrThrow(int fd);

--- a/native_client/kenlm/util/mmap.cc
+++ b/native_client/kenlm/util/mmap.cc
@@ -134,7 +134,7 @@ void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, int
   return ret;
 }
 
-void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, char *file_data, uint64_t offset) {
+void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, const char *file_data, uint64_t offset) {
 #ifdef MAP_POPULATE // Linux specific
   if (prefault) {
     flags |= MAP_POPULATE;
@@ -364,7 +364,7 @@ void MapRead(LoadMethod method, int fd, uint64_t offset, std::size_t size, scope
   }
 }
 
-void MapRead(LoadMethod method, char *file_data, uint64_t offset, std::size_t size, scoped_memory &out) {  
+void MapRead(LoadMethod method, const char *file_data, uint64_t offset, std::size_t size, scoped_memory &out) {
   switch (method) {
     case LAZY:
       out.reset(MapOrThrow(size, false, kFileFlags, false, file_data, offset), size, scoped_memory::MMAP_ALLOCATED);

--- a/native_client/kenlm/util/mmap.cc
+++ b/native_client/kenlm/util/mmap.cc
@@ -141,15 +141,12 @@ void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, cha
   }
 #endif
 #if defined(_WIN32) || defined(_WIN64)
-  
-  TCHAR szName[]=TEXT("Global\\LanguageModelMapping");
-
   int protectC = for_write ? PAGE_READWRITE : PAGE_READONLY;
   int protectM = for_write ? FILE_MAP_WRITE : FILE_MAP_READ;
   uint64_t total_size = size + offset;
   // HANDLE hMapping = CreateFileMapping((HANDLE)_get_osfhandle(fd), NULL, protectC, total_size >> 32, static_cast<DWORD>(total_size), NULL);
 
-  HANDLE hMapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, total_size >> 32, static_cast<DWORD>(total_size), szName);
+  HANDLE hMapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, total_size >> 32, static_cast<DWORD>(total_size), NULL);
   UTIL_THROW_IF(!hMapping, ErrnoException, "CreateFileMapping failed");
   // LPVOID ret = MapViewOfFile(hMapping, protectM, offset >> 32, offset, size);
 

--- a/native_client/kenlm/util/mmap.hh
+++ b/native_client/kenlm/util/mmap.hh
@@ -127,7 +127,7 @@ extern const int kFileFlags;
 
 // Cross-platform, error-checking wrapper for mmap().
 void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, int fd, uint64_t offset = 0);
-void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, char *file_data, uint64_t offset = 0);
+void *MapOrThrow(std::size_t size, bool for_write, int flags, bool prefault, const char *file_data, uint64_t offset = 0);
 
 // msync wrapper
 void SyncOrThrow(void *start, size_t length);
@@ -162,7 +162,7 @@ enum LoadMethod {
 };
 
 void MapRead(LoadMethod method, int fd, uint64_t offset, std::size_t size, scoped_memory &out);
-void MapRead(LoadMethod method, char *file_data, uint64_t offset, std::size_t size, scoped_memory &out);
+void MapRead(LoadMethod method, const char *file_data, uint64_t offset, std::size_t size, scoped_memory &out);
 
 // Open file name with mmap of size bytes, all of which are initially zero.
 void *MapZeroedWrite(int fd, std::size_t size);

--- a/native_client/modelstate.cc
+++ b/native_client/modelstate.cc
@@ -24,7 +24,7 @@ ModelState::~ModelState()
 }
 
 int
-ModelState::init(const char* model_path)
+ModelState::init(const char* model_string, bool init_from_bytes, size_t bufferSize)
 {
   return STT_ERR_OK;
 }

--- a/native_client/modelstate.h
+++ b/native_client/modelstate.h
@@ -31,7 +31,7 @@ struct ModelState {
   ModelState();
   virtual ~ModelState();
 
-  virtual int init(const char* model_path);
+  virtual int init(const char* model_string, bool init_from_bytes, size_t bufferSize);
 
   virtual void compute_mfcc(const std::vector<float>& audio_buffer, std::vector<float>& mfcc_output) = 0;
 

--- a/native_client/stt.cc
+++ b/native_client/stt.cc
@@ -339,20 +339,19 @@ STT_FreeModel(ModelState* ctx)
 
 int
 EnableExternalScorerImpl(ModelState* aCtx,
-                         const char* aScorerString,
-                         bool init_from_bytes,
-                         unsigned int aBufferSize = 0)
+                         const std::string& aPathOrBuffer,
+                         bool aInitFromBuffer)
 {
   std::unique_ptr<Scorer> scorer(new Scorer());
 
   int err;
-  if (init_from_bytes)
-    err = scorer->init(std::string(aScorerString, aBufferSize), init_from_bytes, aCtx->alphabet_);
-  else
-    err = scorer->init(aScorerString, init_from_bytes, aCtx->alphabet_);
+  if (aInitFromBuffer) {
+    err = scorer->init_from_buffer(aPathOrBuffer, aCtx->alphabet_);
+  } else {
+    err = scorer->init_from_filepath(aPathOrBuffer, aCtx->alphabet_);
+  }
 
-
-  if (err != 0) {
+  if (err != STT_ERR_OK) {
     return STT_ERR_INVALID_SCORER;
   }
   aCtx->scorer_ = std::move(scorer);
@@ -371,7 +370,8 @@ STT_EnableExternalScorerFromBuffer(ModelState* aCtx,
                                    const char* aScorerBuffer,
                                    unsigned int aBufferSize)
 {
-  return EnableExternalScorerImpl(aCtx, aScorerBuffer, true, aBufferSize);
+  std::string buffer(aScorerBuffer, aBufferSize);
+  return EnableExternalScorerImpl(aCtx, aScorerBuffer, true);
 }
 
 int

--- a/native_client/stt.cc
+++ b/native_client/stt.cc
@@ -371,7 +371,7 @@ STT_EnableExternalScorerFromBuffer(ModelState* aCtx,
                                    unsigned int aBufferSize)
 {
   std::string buffer(aScorerBuffer, aBufferSize);
-  return EnableExternalScorerImpl(aCtx, aScorerBuffer, true);
+  return EnableExternalScorerImpl(aCtx, buffer, true);
 }
 
 int

--- a/native_client/tflitemodelstate.cc
+++ b/native_client/tflitemodelstate.cc
@@ -159,23 +159,36 @@ getTfliteDelegates()
 }
 
 int
-TFLiteModelState::init(const char* model_path)
+TFLiteModelState::init(const char *model_string, bool init_from_bytes, size_t bufferSize)
 {
-  int err = ModelState::init(model_path);
+  int err = ModelState::init(model_string, init_from_bytes, bufferSize);
   if (err != STT_ERR_OK) {
     return err;
   }
 
-  fbmodel_ = tflite::FlatBufferModel::BuildFromFile(model_path);
-  if (!fbmodel_) {
-    std::cerr << "Error at reading model file " << model_path << std::endl;
-    return STT_ERR_FAIL_INIT_MMAP;
+  if (init_from_bytes) {
+    fbmodel_ = tflite::FlatBufferModel::VerifyAndBuildFromBuffer(model_string, bufferSize);
+    if (!fbmodel_) {
+      std::cerr << "Error at reading model buffer " << std::endl;
+      return STT_ERR_FAIL_INIT_MMAP;
+    }
+  } else {
+    fbmodel_ = tflite::FlatBufferModel::BuildFromFile(model_string);
+    if (!fbmodel_) {
+      std::cerr << "Error at reading model file " << model_string << std::endl;
+      return STT_ERR_FAIL_INIT_MMAP;
+    }
   }
 
   tflite::ops::builtin::BuiltinOpResolver resolver;
   tflite::InterpreterBuilder(*fbmodel_, resolver)(&interpreter_);
   if (!interpreter_) {
-    std::cerr << "Error at InterpreterBuilder for model file " << model_path << std::endl;
+    if (init_from_bytes) {
+      std::cerr << "Error at InterpreterBuilder for model buffer " << std::endl;
+    } else {
+      std::cerr << "Error at InterpreterBuilder for model file " << model_string << std::endl;
+    }
+
     return STT_ERR_FAIL_INTERPRETER;
   }
 

--- a/native_client/tflitemodelstate.cc
+++ b/native_client/tflitemodelstate.cc
@@ -167,7 +167,7 @@ TFLiteModelState::init(const char *model_string, bool init_from_bytes, size_t bu
   }
 
   if (init_from_bytes) {
-    fbmodel_ = tflite::FlatBufferModel::VerifyAndBuildFromBuffer(model_string, bufferSize);
+    fbmodel_ = tflite::FlatBufferModel::BuildFromBuffer(model_string, bufferSize);
     if (!fbmodel_) {
       std::cerr << "Error at reading model buffer " << std::endl;
       return STT_ERR_FAIL_INIT_MMAP;

--- a/native_client/tflitemodelstate.h
+++ b/native_client/tflitemodelstate.h
@@ -29,7 +29,7 @@ struct TFLiteModelState : public ModelState
   TFLiteModelState();
   virtual ~TFLiteModelState();
 
-  virtual int init(const char* model_path) override;
+  virtual int init(const char* model_string, bool init_from_bytes, size_t bufferSize) override;
 
   virtual void compute_mfcc(const std::vector<float>& audio_buffer,
                             std::vector<float>& mfcc_output) override;


### PR DESCRIPTION
Co-authored-by: Bernardo Henz <bernardohenz@gmail.com>
Co-authored-by: Daniele Fernandes <daniele.fernandes@iffarroupilha.edu.br>

Squashed commit of the following:

commit df40e22ee3474096a08acab85fe3d84997720185
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Wed Sep 30 12:18:25 2020 -0300

    -Change string to char* in the API

commit 3b9d2b00bb953b5f44b81143e41b425f4e86682c
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Tue Sep 29 09:17:32 2020 -0300

    Seting a default value for load_from_bytes in load_lm

commit 71e19bc5ba2d8fb5887a075dd4e2abf60e0a450a
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Mon Sep 28 13:05:29 2020 -0300

    load_trie with default value for load_from_bytes

commit 9faeb51f23bd9187316c09c429d08aaf0ec33dba
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Mon Sep 28 11:37:49 2020 -0300

    Fixing API functions exposition

commit dd73ec8711c38089b10614e54dd517815b1f5630
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Mon Sep 28 11:17:30 2020 -0300

    Loading tflite buffer from buffer working

commit 96710415a1c486d6f3ef85916f7bd518212b7391
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Fri Sep 25 12:09:37 2020 -0300

    Exposing methods DS_CreateModelFromBuffer and DS_EnableExternalScorerFromBuffer

commit d6a4e374814f4675e1a441d9997083ceda208b14
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Tue Sep 22 09:21:32 2020 -0300

    removing debug info

commit dc8553b7085d82667beb48c3a11062d9af58f46f
Author: Bernardo Henz <bernardohenz@gmail.com>
Date:   Tue Sep 22 08:24:51 2020 -0300

    Loading ExtScorer from array of bytes

commit 06c23fe6d5dfad85f5c20449515bf273241c0d43
Author: daniele <daniele.fernandes@iffarroupilha.edu.br>
Date:   Wed Sep 9 13:45:49 2020 -0300

    Loading model from both path or array of bytes