### PR TITLE
start work on making model export without mfcc processing

### DIFF
--- a/training/coqui_stt_training/export.py
+++ b/training/coqui_stt_training/export.py
@@ -142,6 +142,7 @@ def export():
             # AudioSpectrogram and Mfcc ops are custom but have built-in kernels in TFLite
             converter.allow_custom_ops = True
 
+            # When exporting without audio processing, complain about custom ops
             if Config.export_minimal:
                  converter.allow_custom_ops = False
 

--- a/training/coqui_stt_training/util/config.py
+++ b/training/coqui_stt_training/util/config.py
@@ -609,6 +609,9 @@ class BaseSttConfig(Coqpit):
     export_tflite: bool = field(
         default=True, metadata=dict(help="export a graph ready for TF Lite engine")
     )
+    export_minimal: bool = field(
+        default=False, metadata=dict(help="export a minimal graph without inbuilt audio processing")
+    )
     export_quantize: bool = field(
         default=True,
         metadata=dict(help="export a quantized model (optimized for size)"),


### PR DESCRIPTION
WiP. Start work on exporting TFlite models that can work in tfjs. There are probably several parts to this:
- Remove the audio processing and do it outside the model (note that audio processing stuff is [not supported](https://github.com/tensorflow/tfjs/issues/1728)).
- Generate MFCCs outside (perhaps using something like [this](https://github.com/tensorflow/tfjs-models/tree/master/speech-commands/training/soft-fft/utils) or [this](https://pulakk.github.io/Live-Audio-MFCC/tutorial))
- Pass in input with MFCCs generated outside.

Another option would be to just add the custom ops to tfjs-tflite, but probably harder.