### PR TITLE
Add flag to save best lm alpha and beta values to disk

### DIFF
--- a/lm_optimizer.py
+++ b/lm_optimizer.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, print_function
 
 import sys
 
+import yaml
+
 import optuna
 import tensorflow.compat.v1 as tfv1
 from coqui_stt_ctcdecoder import Scorer
@@ -51,6 +53,11 @@ def objective(trial):
     return cer if is_character_based else wer
 
 
+def save_best_val(dict_to_save_as_yaml, path_to_yaml):
+    with open(path_to_yaml, "w") as f:
+        yaml.dump(dict_to_save_as_yaml, f)
+
+
 def main():
     initialize_globals_from_cli()
     early_training_checks()
@@ -81,6 +88,14 @@ def main():
             study.best_value,
         )
     )
+
+    if Config.save_ctc_val:
+        struct = {}
+        struct["lm_alpha"] = study.best_params.get("lm_alpha")
+        struct["lm_beta"] = study.best_params.get("lm_beta")
+        struct["wer"] = study.best_value
+
+        save_best_val(struct, Config.save_ctc_val)
 
 
 if __name__ == "__main__":

--- a/training/coqui_stt_training/util/config.py
+++ b/training/coqui_stt_training/util/config.py
@@ -857,6 +857,12 @@ class BaseSttConfig(Coqpit):
             help="the number of trials to run during hyperparameter optimization."
         ),
     )
+    save_ctc_val: str = field(
+        default=None,
+        metadata=dict(
+            help="Path to YAML file to save best alpha and beta CTC decoder values"
+        ),
+    )
     # sphinx-doc: training_ref_flags_end
 
 
@@ -872,7 +878,7 @@ def initialize_globals_from_args(**override_args):
 
 
 def initialize_globals_from_instance(config):
-    """ Initialize Config singleton from an existing instance """
+    """Initialize Config singleton from an existing instance"""
     _ConfigSingleton._config = config  # pylint: disable=protected-access
 
 


### PR DESCRIPTION
# `--save_ctc_val`

This option saves the best values of alpha and beta for the CTC decoder (LM optimization step).

## Why is this useful?

You can save those values inside a YAML file. You can then programmatically fetch those values with your favorite programing language.