### PR TITLE
Expose raw tokens and timesteps in decoder Python package

### DIFF
--- a/native_client/ctcdecode/__init__.py
+++ b/native_client/ctcdecode/__init__.py
@@ -1,4 +1,5 @@
 import enum
+from collections import namedtuple
 
 from . import swigwrapper  # pylint: disable=import-self
 
@@ -113,6 +114,11 @@ class Scorer(swigwrapper.Scorer):
             self.reset_params(alpha, beta)
 
 
+DecodeResult = namedtuple(
+    "DecodeResult", ["confidence", "transcript", "tokens", "timesteps"]
+)
+
+
 def ctc_beam_search_decoder(
     probs_seq,
     alphabet,
@@ -161,7 +167,13 @@ def ctc_beam_search_decoder(
         num_results,
     )
     beam_results = [
-        (res.confidence, alphabet.Decode(res.tokens)) for res in beam_results
+        DecodeResult(
+            res.confidence,
+            alphabet.Decode(res.tokens),
+            [int(t) for t in res.tokens],
+            [int(t) for t in res.timesteps],
+        )
+        for res in beam_results
     ]
     return beam_results
 
@@ -222,7 +234,15 @@ def ctc_beam_search_decoder_batch(
         num_results,
     )
     batch_beam_results = [
-        [(res.confidence, alphabet.Decode(res.tokens)) for res in beam_results]
+        [
+            DecodeResult(
+                res.confidence,
+                alphabet.Decode(res.tokens),
+                [int(t) for t in res.tokens],
+                [int(t) for t in res.timesteps],
+            )
+            for res in beam_results
+        ]
         for beam_results in batch_beam_results
     ]
     return batch_beam_results

--- a/training/coqui_stt_training/evaluate.py
+++ b/training/coqui_stt_training/evaluate.py
@@ -140,7 +140,7 @@ def evaluate(test_csvs, create_model):
                     cutoff_prob=Config.cutoff_prob,
                     cutoff_top_n=Config.cutoff_top_n,
                 )
-                predictions.extend(d[0][1] for d in decoded)
+                predictions.extend(d[0].transcript for d in decoded)
                 ground_truths.extend(
                     sparse_tensor_value_to_texts(batch_transcripts, Config.alphabet)
                 )

--- a/training/coqui_stt_training/training_graph_inference.py
+++ b/training/coqui_stt_training/training_graph_inference.py
@@ -67,8 +67,8 @@ def do_single_file_inference(input_file_path):
             cutoff_prob=Config.cutoff_prob,
             cutoff_top_n=Config.cutoff_top_n,
         )
-        # Print highest probability result
-        print(decoded[0][1])
+        # Print highest probability transcript
+        print(decoded[0].transcript)
 
 
 def main():


### PR DESCRIPTION
Currently we're discarding everything but confidence and transcript.