### PR TITLE
Pin webdataset requirement for Python 3.7 compat (Fixes #2168)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def main():
         "sox",
         "soundfile",
         "tqdm",
-        "webdataset",
+        "webdataset==0.1.103",
         "miniaudio",
     ]
 


### PR DESCRIPTION
[webdataset silently broke compatibility with Python 3.6 and 3.7 on the latest release](https://github.com/webdataset/webdataset/issues/166)
