### PR TITLE
Workaround batch size memory test

### DIFF
--- a/bin/run-ci-mailabs_time.sh
+++ b/bin/run-ci-mailabs_time.sh
@@ -33,8 +33,6 @@ python -u train.py --alphabet_config_path ${alphabet_path} \
   --scorer_path ${scorer_path} \
   --audio_sample_rate ${audio_sample_rate} \
   --export_tflite false \
-  --automatic_mixed_precision 1 \
-  --train_cudnn 1 \
   --log_level 0
 
 exit_code=$?

--- a/bin/run-ci-mailabs_time.sh
+++ b/bin/run-ci-mailabs_time.sh
@@ -2,24 +2,23 @@
 
 set -xe
 
-mailabs_dir=$1 #"./data/M-AILABS"
-mailabs_lang=$2 #"fr_FR"
+mailabs_dir=$1   #"./data/M-AILABS"
+mailabs_lang=$2  #"fr_FR"
 alphabet_path=$3 #"./data/fr_FR/alphabet.txt"
-scorer_path=$4 #"./data/fr_FR/fr_lm.scorer"
+scorer_path=$4   #"./data/fr_FR/fr_lm.scorer"
 mailabs_train_csv="${mailabs_dir}${mailabs_lang}/${mailabs_lang}_train.csv"
 mailabs_dev_csv="${mailabs_dir}${mailabs_lang}/${mailabs_lang}_test.csv"
 mailabs_test_csv="${mailabs_dir}${mailabs_lang}/${mailabs_lang}_test.csv"
-
 
 epoch_count=1
 audio_sample_rate=16000
 
 if [ ! -f "${mailabs_train_csv}" ]; then
-    echo "Downloading and preprocessing M-AILABS data, saving in ${mailabs_dir}${mailabs_lang}/."
-    python -u bin/import_m-ailabs.py ${mailabs_dir} --language ${mailabs_lang}
-fi;
+  echo "Downloading and preprocessing M-AILABS data, saving in ${mailabs_dir}${mailabs_lang}/."
+  python -u bin/import_m-ailabs.py ${mailabs_dir} --language ${mailabs_lang}
+fi
 
-st=`date +%s`
+st=$(date +%s)
 echo "Index 0 starts at ${st}."
 
 python -u train.py --alphabet_config_path ${alphabet_path} \
@@ -30,18 +29,18 @@ python -u train.py --alphabet_config_path ${alphabet_path} \
   --test_files ${ldc93s1_csv} --test_batch_size 32 \
   --n_hidden 100 --epochs $epoch_count \
   --max_to_keep 1 --checkpoint_dir '/tmp/mailabs_ckpt' \
-  --learning_rate 0.001 --dropout_rate 0.05  --export_dir '/tmp/mailabs_train' \
+  --learning_rate 0.001 --dropout_rate 0.05 --export_dir '/tmp/mailabs_train' \
   --scorer_path ${scorer_path} \
   --audio_sample_rate ${audio_sample_rate} \
-  --export_tflite false
-  --automatic_mixed_precision 1
-  --train_cudnn 1
+  --export_tflite false \
+  --automatic_mixed_precision 1 \
+  --train_cudnn 1 \
   --log_level 0
 
 exit_code=$?
 
-ent=`date +%s`
+ent=$(date +%s)
 echo "Index -1 ends at ${ent}"
 
-ext=`expr $end_time - $start_time`
+ext=$(expr $end_time - $start_time)
 echo "Execution took ${ext} seconds to return exit code ${exit_code}."

--- a/bin/run-ci-mailabs_time.sh
+++ b/bin/run-ci-mailabs_time.sh
@@ -42,5 +42,5 @@ exit_code=$?
 ent=$(date +%s)
 echo "Index -1 ends at ${ent}"
 
-ext=$(expr $end_time - $start_time)
+ext=$(expr $ent - $st)
 echo "Execution took ${ext} seconds to return exit code ${exit_code}."

--- a/bin/run-ci-mailabs_time.sh
+++ b/bin/run-ci-mailabs_time.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -xe
+
+mailabs_dir=$1 #"./data/M-AILABS"
+mailabs_lang=$2 #"fr_FR"
+alphabet_path=$3 #"./data/fr_FR/alphabet.txt"
+scorer_path=$4 #"./data/fr_FR/fr_lm.scorer"
+mailabs_train_csv="${mailabs_dir}${mailabs_lang}/${mailabs_lang}_train.csv"
+mailabs_dev_csv="${mailabs_dir}${mailabs_lang}/${mailabs_lang}_test.csv"
+mailabs_test_csv="${mailabs_dir}${mailabs_lang}/${mailabs_lang}_test.csv"
+
+
+epoch_count=1
+audio_sample_rate=16000
+
+if [ ! -f "${mailabs_train_csv}" ]; then
+    echo "Downloading and preprocessing M-AILABS data, saving in ${mailabs_dir}${mailabs_lang}/."
+    python -u bin/import_m-ailabs.py ${mailabs_dir} --language ${mailabs_lang}
+fi;
+
+st=`date +%s`
+echo "Index 0 starts at ${st}."
+
+python -u train.py --alphabet_config_path ${alphabet_path} \
+  --show_progressbar false --early_stop false \
+  --train_files ${mailabs_train_csv} --train_batch_size 32 \
+  --feature_cache '/tmp/mailabs_cache' \
+  --dev_files ${ldc93s1_csv} --dev_batch_size 32 \
+  --test_files ${ldc93s1_csv} --test_batch_size 32 \
+  --n_hidden 100 --epochs $epoch_count \
+  --max_to_keep 1 --checkpoint_dir '/tmp/mailabs_ckpt' \
+  --learning_rate 0.001 --dropout_rate 0.05  --export_dir '/tmp/mailabs_train' \
+  --scorer_path ${scorer_path} \
+  --audio_sample_rate ${audio_sample_rate} \
+  --export_tflite false
+  --automatic_mixed_precision 1
+  --train_cudnn 1
+
+exit_code=$?
+
+ent=`date +%s`
+echo "Index -1 ends at ${ent}"
+
+ext=`expr $end_time - $start_time`
+echo "Execution took ${ext} seconds to return exit code ${exit_code}."

--- a/bin/run-ci-mailabs_time.sh
+++ b/bin/run-ci-mailabs_time.sh
@@ -36,6 +36,7 @@ python -u train.py --alphabet_config_path ${alphabet_path} \
   --export_tflite false
   --automatic_mixed_precision 1
   --train_cudnn 1
+  --log_level 0
 
 exit_code=$?
 

--- a/bin/run-ci-mailabs_time.sh
+++ b/bin/run-ci-mailabs_time.sh
@@ -21,7 +21,7 @@ fi
 st=$(date +%s)
 echo "Index 0 starts at ${st}."
 
-python -u train.py --alphabet_config_path ${alphabet_path} \
+python -m coqui_stt_training.train --alphabet_config_path ${alphabet_path} \
   --show_progressbar false --early_stop false \
   --train_files ${mailabs_train_csv} --train_batch_size 32 \
   --feature_cache '/tmp/mailabs_cache' \
@@ -33,7 +33,8 @@ python -u train.py --alphabet_config_path ${alphabet_path} \
   --scorer_path ${scorer_path} \
   --audio_sample_rate ${audio_sample_rate} \
   --export_tflite false \
-  --log_level 0
+  --log_level 0 \
+  --skip_batch_test true
 
 exit_code=$?
 

--- a/training/coqui_stt_training/train.py
+++ b/training/coqui_stt_training/train.py
@@ -324,14 +324,15 @@ def create_training_datasets(
 
 
 def train():
-    log_info("Performing dummy training to check for memory problems.")
-    log_info(
-        "If the following process crashes, you likely have batch sizes "
-        "that are too big for your available system memory (or GPU memory)."
-    )
-    train_impl(epochs=1, reverse=True, limit=Config.train_batch_size * 3, write=False)
+    if not Config.skip_batch_test:
+        log_info("Performing dummy training to check for memory problems.")
+        log_info(
+            "If the following process crashes, you likely have batch sizes "
+            "that are too big for your available system memory (or GPU memory)."
+        )
+        train_impl(epochs=1, reverse=True, limit=Config.train_batch_size * 3, write=False)
 
-    log_info("Dummy run finished without problems, now starting real training process.")
+        log_info("Dummy run finished without problems, now starting real training process.")
     train_impl(epochs=Config.epochs, silent_load=True)
 
 

--- a/training/coqui_stt_training/util/config.py
+++ b/training/coqui_stt_training/util/config.py
@@ -503,6 +503,14 @@ class BaseSttConfig(Coqpit):
         metadata=dict(help="number of elements per batch on the exported graph"),
     )
 
+    # Memory test
+    skip_batch_test: bool = field(
+        default=False,
+        metadata=dict(
+            help="skip batch size memory test using before training"
+        )
+    )
+
     # Performance
     inter_op_parallelism_threads: int = field(
         default=0,

--- a/training/coqui_stt_training/util/config.py
+++ b/training/coqui_stt_training/util/config.py
@@ -507,8 +507,8 @@ class BaseSttConfig(Coqpit):
     skip_batch_test: bool = field(
         default=False,
         metadata=dict(
-            help="skip batch size memory test using before training"
-        )
+            help="skip batch size memory test before training"
+        ),
     )
 
     # Performance


### PR DESCRIPTION
This workaround for #2195 introduces the flag `--skip_batch_test`.
It's boolean and negative by default so the memory test is ran by default. However you can now set it to `true` to bypass the test and totally avoid the aforementioned issue.
 
Logs for [run-ci-mailabs-time.sh](https://gist.github.com/wasertech/ba3a32f09f428f6cb2c47c23db405c5a)