### PR TITLE
export to tflite using python37 venv

### DIFF
--- a/Dockerfile.train
+++ b/Dockerfile.train
@@ -7,10 +7,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential cmake libboost-system-dev \
-    libboost-thread-dev libboost-program-options-dev \
-    libboost-test-dev libeigen3-dev zlib1g-dev \
-    libbz2-dev liblzma-dev && \
+        build-essential cmake libboost-system-dev \
+        libboost-thread-dev libboost-program-options-dev \
+        libboost-test-dev libeigen3-dev zlib1g-dev \
+        libbz2-dev liblzma-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Build KenLM to generate new scorers
@@ -21,11 +21,12 @@ RUN cd /code/kenlm && \
     cd build && \
     cmake .. && \
     make -j $(nproc) || \
-    ( echo "ERROR: Failed to build KenLM."; \
-    echo "ERROR: Make sure you update the kenlm submodule on host before building this Dockerfile."; \
-    echo "ERROR: $ cd STT; git submodule update --init kenlm"; \
-    exit 1; )
-
+    ( \
+        echo "ERROR: Failed to build KenLM." \
+        echo "ERROR: Make sure you update the kenlm submodule on host before building this Dockerfile." \
+        echo "ERROR: $ cd STT; git submodule update --init kenlm" \
+        exit 1 \
+    )
 
 FROM nvcr.io/nvidia/tensorflow:22.02-tf1-py3
 ENV DEBIAN_FRONTEND=noninteractive
@@ -39,12 +40,24 @@ RUN apt-get update && \
         libsndfile1 \
         sox \
         libsox-fmt-mp3 \
-        python3-venv && \
+        python3-venv \
+        software-properties-common && \
     rm -rf /var/lib/apt/lists/*
+
+# For exporting using TFLite
+RUN add-apt-repository ppa:deadsnakes/ppa -y
+
+RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
+    python3.7 \
+    python3.7-venv
 
 RUN python3 -m venv --system-site-packages /venv
 ENV VIRTUAL_ENV=/venv
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Venv for upstream tensorflow with tflite api
+RUN python3.7 -m venv /tflite-venv
+
+ENV PATH="$VIRTUAL_ENV/bin:/tflite-venv/bin:$PATH"
 
 # Make sure pip and its dependencies are up-to-date
 RUN pip install --upgrade pip wheel setuptools
@@ -69,13 +82,16 @@ COPY --from=kenlm-build /code/kenlm/build/bin /code/kenlm/build/bin
 
 # Pre-built native client tools
 RUN LATEST_STABLE_RELEASE=$(curl "https://api.github.com/repos/coqui-ai/STT/releases/latest" | python -c 'import sys; import json; print(json.load(sys.stdin)["tag_name"])') \
- bash -c 'curl -L https://github.com/coqui-ai/STT/releases/download/${LATEST_STABLE_RELEASE}/native_client.tflite.Linux.tar.xz | tar -xJvf -'
+    bash -c 'curl -L https://github.com/coqui-ai/STT/releases/download/${LATEST_STABLE_RELEASE}/native_client.tflite.Linux.tar.xz | tar -xJvf -'
 
 # Install STT
 # No need for the decoder since we did it earlier
 # TensorFlow GPU should already be installed on the base image,
 # and we don't want to break that
 RUN DS_NODECODER=y DS_NOTENSORFLOW=y pip install --upgrade -e .
+
+# Install coqui_stt_training (inside tf-venv) for exporting models using tflite
+RUN /tflite-venv/bin/pip install -e .
 
 # Copy rest of the code and test training
 COPY . /code

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ def main():
         "opuslib == 2.0.0",
         "pandas",
         "progressbar2",
+        "protobuf <= 3.20.1",
         "pyogg >= 0.6.14a1",
         "resampy >= 0.2.2",
         "requests",

--- a/training/coqui_stt_training/export.py
+++ b/training/coqui_stt_training/export.py
@@ -132,7 +132,9 @@ def export():
                 log_error(
                     "Couldn't access TFLite API in TensorFlow package. "
                     "The NVIDIA TF1 docker image removes the TFLite API, so you'll need "
-                    "to save the checkpoint outside of Docker and then export it using "
+                    "to use the separate virtual environment to call the export module: \n"
+                    "    /tflite-venv/bin/python -m coqui_stt_training.export --checkpoint_dir ... --export_dir ...\n"
+                    "You can also save the checkpoint outside of Docker and then export it using "
                     "the training package directly: \n"
                     "    pip install coqui_stt_training\n"
                     "    python -m coqui_stt_training.export --checkpoint_dir ... --export_dir ...\n"


### PR DESCRIPTION
This PR makes available a new `venv` using `python3.7` to export your checkpoints to the TFLite format.

Instead of using the image' system python (3.8), use python 3.7 from venv at `/tflite-venv/bin/python`.

```bash
root@65576a3b3080:/code# /tflite-venv/bin/python -m coqui_stt_training.export --alphabet_config_path /mnt/models/alphabet.txt --scorer_path /mnt/lm/kenlm.scorer --feature_cache /mnt/sources/feature_cache --n_hidden 2048 --beam_width 500 --lm_alpha 1.6383103526118539 --lm_beta 0.1291025653672666 --load_evaluate best --checkpoint_dir /mnt/checkpoints/ --export_dir /mnt/models/ --export_tflite true --export_author_id CommonVoice-FR-Team --export_model_version 0.9 --export_contact_info https://discourse.mozilla.org/c/voice/fr --export_license MIT-0 --export_language fr-FR --export_min_stt_version 1.0.0 --export_max_stt_version 1.4.0 --export_model_name cv-fr-tflite
I Exporting the model...
I Loading best validating checkpoint from /mnt/checkpoints/best_dev-0
I Loading variable from checkpoint: cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/bias
I Loading variable from checkpoint: cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/kernel
I Loading variable from checkpoint: layer_1/bias
I Loading variable from checkpoint: layer_1/weights
I Loading variable from checkpoint: layer_2/bias
I Loading variable from checkpoint: layer_2/weights
I Loading variable from checkpoint: layer_3/bias
I Loading variable from checkpoint: layer_3/weights
I Loading variable from checkpoint: layer_5/bias
I Loading variable from checkpoint: layer_5/weights
I Loading variable from checkpoint: layer_6/bias
I Loading variable from checkpoint: layer_6/weights
I Models exported at /mnt/models/
I Model metadata file saved to /mnt/models/CommonVoice-FR-Team_cv-fr-tflite_0.9.md. Before submitting the exported model for publishing make sure all information in the metadata file is correct, and complete the URL fields.
```

See my logs [here](https://gist.github.com/wasertech/fa77e09a05dce8844c2678ebf4cb61c5).
See #2220 for context.