### PR TITLE
Remove `convert_graphdef_memmapped_format`

### DIFF
--- a/Dockerfile.train
+++ b/Dockerfile.train
@@ -67,10 +67,6 @@ COPY training /code/training
 RUN mkdir -p /code/kenlm/build/
 COPY --from=kenlm-build /code/kenlm/build/bin /code/kenlm/build/bin
 
-# Tool to convert output graph for inference
-RUN curl -L https://github.com/coqui-ai/STT/releases/download/v0.9.3/convert_graphdef_memmapped_format.linux.amd64.zip | funzip > convert_graphdef_memmapped_format && \
-    chmod +x convert_graphdef_memmapped_format
-
 # Pre-built native client tools
 RUN LATEST_STABLE_RELEASE=$(curl "https://api.github.com/repos/coqui-ai/STT/releases/latest" | python -c 'import sys; import json; print(json.load(sys.stdin)["tag_name"])') \
  bash -c 'curl -L https://github.com/coqui-ai/STT/releases/download/${LATEST_STABLE_RELEASE}/native_client.tflite.Linux.tar.xz | tar -xJvf -'


### PR DESCRIPTION
TensorFlow dropped protobuf support and so did we. There is no need for `convert_graphdef_memmapped_format` to be installed in our image by default.

If you read this and still need it, just install it manually instead:
```bash
# Download and extract convert_graphdef_memmapped_format
curl -L https://github.com/coqui-ai/STT/releases/download/v0.9.3/convert_graphdef_memmapped_format.linux.amd64.zip | funzip > convert_graphdef_memmapped_format

# Make it executable
chmod +x convert_graphdef_memmapped_format 
```