### PR TITLE
Fix Android AAR+APK build on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3494,6 +3494,12 @@ jobs:
           cache: "gradle"
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
+      - name: Install Android NDK r19c
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r19c
+          add-to-path: false
       # This particular version of CMake confuses Gradle by not being semver.
       # We're fine with 3.10.2 which is also installed. Keep an eye on the
       # virtual environments though:
@@ -3503,8 +3509,12 @@ jobs:
           ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall 'cmake;3.18.1'
       - run: |
           make GRADLE="./gradlew " -C native_client/java
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       - run: |
           make GRADLE="./gradlew " -C native_client/java maven-bundle
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       - uses: actions/upload-artifact@v2
         with:
           name: "app.apk"


### PR DESCRIPTION
The mentioned workflow is failing due to the used image changing the default Android NDK version from 21 to 23. This attempts to force the use of NDK 19c, which is what is currently being used to build the libs: https://github.com/coqui-ai/STT/blob/922fe39eadab6e5e5c6384c4f5b93adb38b815c1/ci_scripts/tf-vars.sh#L19-L20

# Pull request guidelines

Welcome to the 🐸STT project! We are excited to see your interest, and appreciate your support!

This repository is governed by the Contributor Covenant Code of Conduct. For more details, see the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file.

In order to make a good pull request, please see our [CONTRIBUTING.rst](CONTRIBUTING.rst) file, in particular make sure you have set-up and run the pre-commit hook to check your changes for code style violations.

Before accepting your pull request, you will be asked to sign a [Contributor License Agreement](https://cla-assistant.io/coqui-ai/STT).

This [Contributor License Agreement](https://cla-assistant.io/coqui-ai/STT):

- Protects you, Coqui, and the users of the code.
- Does not change your rights to use your contributions for any purpose.
- Does not change the license of the 🐸STT project. It just makes the terms of your contribution clearer and lets us know you are OK to contribute.
