### PR TITLE
Allow loading model from buffer in nodejs

### DIFF
--- a/native_client/javascript/index.ts
+++ b/native_client/javascript/index.ts
@@ -169,14 +169,18 @@ export class Model {
     _impl: any;
 
     /**
-     * @param aModelPath The path to the frozen model graph.
+     * @param aModelString Either the path to the frozen model graph or the frozen model's bytes.
+     * @param loadFromBytes Wheter to load the model from bytes or from a file.
      *
      * @throws on error
      */
-    constructor(aModelPath: string) {
+    constructor(aModelString: string, loadFromBytes: boolean = false) {
         this._impl = null;
 
-        const [status, impl] = binding.CreateModel(aModelPath);
+        let status, impl;
+        if (loadFromBytes) [status, impl] = binding.CreateModelFromBuffer(aModelString, aModelString.length);
+        else [status, impl] = binding.CreateModel(aModelString);
+
         if (status !== 0) {
             throw `CreateModel failed: ${binding.ErrorCodeToErrorMessage(status)} (0x${status.toString(16)})`;
         }

--- a/native_client/javascript/index.ts
+++ b/native_client/javascript/index.ts
@@ -169,17 +169,17 @@ export class Model {
     _impl: any;
 
     /**
-     * @param aModelString Either the path to the frozen model graph or the frozen model's bytes.
+     * @param aModelData Either the path to the frozen model graph or the frozen model's bytes.
      * @param loadFromBytes Wheter to load the model from bytes or from a file.
      *
      * @throws on error
      */
-    constructor(aModelString: string, loadFromBytes: boolean = false) {
+    constructor(aModelData: string | Uint8Array, loadFromBytes: boolean = false) {
         this._impl = null;
 
         let status, impl;
-        if (loadFromBytes) [status, impl] = binding.CreateModelFromBuffer(aModelString, aModelString.length);
-        else [status, impl] = binding.CreateModel(aModelString);
+        if (loadFromBytes) [status, impl] = binding.CreateModelFromBuffer(aModelData);
+        else [status, impl] = binding.CreateModel(aModelData);
 
         if (status !== 0) {
             throw `CreateModel failed: ${binding.ErrorCodeToErrorMessage(status)} (0x${status.toString(16)})`;

--- a/native_client/javascript/stt.i
+++ b/native_client/javascript/stt.i
@@ -59,8 +59,7 @@ using namespace node;
 }
 
 %typemap(argout) ModelState **retval {
-  //TODO: check if the swig API is updated
-  $result = SWIGV8_ARRAY_NEW();
+  $result = SWIGV8_ARRAY_NEW(0);
   SWIGV8_AppendOutput($result, SWIG_From_int(result));
   // owned by the application. NodeJS does not guarantee the finalizer will be called so applications must call FreeMetadata themselves.
   %append_output(SWIG_NewPointerObj(%as_voidptr(*$1), $*1_descriptor, 0));
@@ -74,8 +73,7 @@ using namespace node;
 }
 
 %typemap(argout) StreamingState **retval {
-  //TODO: check if the swig API is updated
-  $result = SWIGV8_ARRAY_NEW();
+  $result = SWIGV8_ARRAY_NEW(0);
   SWIGV8_AppendOutput($result, SWIG_From_int(result));
   // not owned, STT_FinishStream deallocates StreamingState
   %append_output(SWIG_NewPointerObj(%as_voidptr(*$1), $*1_descriptor, 0));
@@ -85,16 +83,14 @@ using namespace node;
 %nodefaultdtor ModelState;
 
 %typemap(out) TokenMetadata* %{
-  //TODO: check if the swig API is updated
-  $result = SWIGV8_ARRAY_NEW();
+  $result = SWIGV8_ARRAY_NEW(0);
   for (int i = 0; i < arg1->num_tokens; ++i) {
     SWIGV8_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr(&result[i]), SWIGTYPE_p_TokenMetadata, 0));
   }
 %}
 
 %typemap(out) CandidateTranscript* %{
-  //TODO: check if the swig API is updated
-  $result = SWIGV8_ARRAY_NEW();
+  $result = SWIGV8_ARRAY_NEW(0);
   for (int i = 0; i < arg1->num_transcripts; ++i) {
     SWIGV8_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr(&result[i]), SWIGTYPE_p_CandidateTranscript, 0));
   }

--- a/native_client/javascript/stt.i
+++ b/native_client/javascript/stt.i
@@ -26,6 +26,18 @@ using namespace node;
   $2 = ($2_ltype)(bufferLength / 2);
 }
 
+// Map Uint8Array to char* for STT_CreateModelFromBuffer 
+%typemap(in) (const char *aModelBuffer, unsigned int aBufferSize) {
+    if (args[0]->IsUint8Array()) {
+        v8::Local<v8::Uint8Array> myarr = args[0].As<v8::Uint8Array>();
+        unsigned int offset = myarr->ByteOffset();
+        arg1 = (char*)((char*)myarr->Buffer()->GetBackingStore()->Data() + offset);
+        arg2 = myarr->Length();
+    } else {
+      SWIG_exception_fail(SWIG_ERROR, "Model buffer must be of type Uint8Array.");
+    }
+}
+
 // apply to STT_FeedAudioContent and STT_SpeechToText
 %apply (short* IN_ARRAY1, int DIM1) {(const short* aBuffer, unsigned int aBufferSize)};
 

--- a/native_client/javascript/stt.i
+++ b/native_client/javascript/stt.i
@@ -26,16 +26,16 @@ using namespace node;
   $2 = ($2_ltype)(bufferLength / 2);
 }
 
-// Map Uint8Array to char* for STT_CreateModelFromBuffer 
+// Map Uint8Array to char* for STT_CreateModelFromBuffer
 %typemap(in) (const char *aModelBuffer, unsigned int aBufferSize) {
-    if (args[0]->IsUint8Array()) {
-        v8::Local<v8::Uint8Array> myarr = args[0].As<v8::Uint8Array>();
-        unsigned int offset = myarr->ByteOffset();
-        arg1 = (char*)((char*)myarr->Buffer()->GetBackingStore()->Data() + offset);
-        arg2 = myarr->Length();
-    } else {
-      SWIG_exception_fail(SWIG_ERROR, "Model buffer must be of type Uint8Array.");
-    }
+  if (args[0]->IsUint8Array()) {
+    v8::Local<v8::Uint8Array> myarr = args[0].As<v8::Uint8Array>();
+    unsigned int offset = myarr->ByteOffset();
+    arg1 = (char*)((char*)myarr->Buffer()->GetBackingStore()->Data() + offset);
+    arg2 = myarr->Length();
+  } else {
+    SWIG_exception_fail(SWIG_ERROR, "Model buffer must be of type Uint8Array.");
+  }
 }
 
 // apply to STT_FeedAudioContent and STT_SpeechToText

--- a/native_client/javascript/stt.i
+++ b/native_client/javascript/stt.i
@@ -47,7 +47,8 @@ using namespace node;
 }
 
 %typemap(argout) ModelState **retval {
-  $result = SWIGV8_ARRAY_NEW(0);
+  //TODO: check if the swig API is updated
+  $result = SWIGV8_ARRAY_NEW();
   SWIGV8_AppendOutput($result, SWIG_From_int(result));
   // owned by the application. NodeJS does not guarantee the finalizer will be called so applications must call FreeMetadata themselves.
   %append_output(SWIG_NewPointerObj(%as_voidptr(*$1), $*1_descriptor, 0));
@@ -61,7 +62,8 @@ using namespace node;
 }
 
 %typemap(argout) StreamingState **retval {
-  $result = SWIGV8_ARRAY_NEW(0);
+  //TODO: check if the swig API is updated
+  $result = SWIGV8_ARRAY_NEW();
   SWIGV8_AppendOutput($result, SWIG_From_int(result));
   // not owned, STT_FinishStream deallocates StreamingState
   %append_output(SWIG_NewPointerObj(%as_voidptr(*$1), $*1_descriptor, 0));
@@ -71,14 +73,16 @@ using namespace node;
 %nodefaultdtor ModelState;
 
 %typemap(out) TokenMetadata* %{
-  $result = SWIGV8_ARRAY_NEW(0);
+  //TODO: check if the swig API is updated
+  $result = SWIGV8_ARRAY_NEW();
   for (int i = 0; i < arg1->num_tokens; ++i) {
     SWIGV8_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr(&result[i]), SWIGTYPE_p_TokenMetadata, 0));
   }
 %}
 
 %typemap(out) CandidateTranscript* %{
-  $result = SWIGV8_ARRAY_NEW(0);
+  //TODO: check if the swig API is updated
+  $result = SWIGV8_ARRAY_NEW();
   for (int i = 0; i < arg1->num_transcripts; ++i) {
     SWIGV8_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr(&result[i]), SWIGTYPE_p_CandidateTranscript, 0));
   }


### PR DESCRIPTION
This PR allows loading models from buffer for the nodejs bindings. 
Some important remarks:

1. I am not very familiar with SWIG, so it would be nice to have someone that is reviewing these changes.
2. I tried to keep aModelData as a string to avoid the multiple allowed types, but converting the string back to an UInt8Array would provide different results. Could we keep the UInt8Array as an allowed input type?