### PR TITLE
Add python 3.8 wheel artifacts for arm and aarch architectures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1137,7 +1137,13 @@ jobs:
           name: stt-tflite-3.7-armv7.whl
       - uses: actions/download-artifact@v2
         with:
+          name: stt-tflite-3.8-armv7.whl
+      - uses: actions/download-artifact@v2
+        with:
           name: stt-tflite-3.7-aarch64.whl
+      - uses: actions/download-artifact@v2
+        with:
+          name: stt-tflite-3.8-aarch64.whl
       - name: Upload artifacts to GitHub release
         uses: ./.github/actions/upload-release-asset
         with:
@@ -2867,7 +2873,7 @@ jobs:
     needs: [build-lib-LinuxArmv7, swig_Linux]
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
     env:
       DEBIAN_FRONTEND: "noninteractive"
       SYSTEM_TARGET: rpi3
@@ -2996,7 +3002,7 @@ jobs:
     needs: [build-lib-LinuxAarch64, swig_Linux]
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
     env:
       DEBIAN_FRONTEND: "noninteractive"
       SYSTEM_TARGET: rpi3-armv8
@@ -3214,7 +3220,7 @@ jobs:
     strategy:
       matrix:
         arch: [ "armv7", "aarch64" ]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
         models: ["test", "prod"]
         samplerate: ["8000", "16000"]
     env:


### PR DESCRIPTION
Not quite sure why we only release wheel artifacts for `arm` and `aarch` with python 3.7 support.  This PR aims to support python 3.8 for `arm` and `aarch` wheel artifacts.

Please let me know if I missed anything 😄 

FWIW, I have tried installing the `manylinux` wheel artifact and is not working for me:

```
ubuntu@fd8a43352cf3:~$ wget https://github.com/coqui-ai/STT/releases/download/v1.3.0/stt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl
--2022-07-27 10:27:24--  https://github.com/coqui-ai/STT/releases/download/v1.3.0/stt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl
Resolving github.com (github.com)... 140.82.113.3
Connecting to github.com (github.com)|140.82.113.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/344354127/74d21bb2-3fd5-47a6-98e1-62c4798e88bf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220727%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220727T102611Z&X-Amz-Expires=300&X-Amz-Signature=94d0a43d78691e5aec0c6794344a9edc8ddcf60c8a63af703cfd3a989d58acd2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=344354127&response-content-disposition=attachment%3B%20filename%3Dstt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl&response-content-type=application%2Foctet-stream [following]
--2022-07-27 10:27:25--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/344354127/74d21bb2-3fd5-47a6-98e1-62c4798e88bf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220727%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220727T102611Z&X-Amz-Expires=300&X-Amz-Signature=94d0a43d78691e5aec0c6794344a9edc8ddcf60c8a63af703cfd3a989d58acd2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=344354127&response-content-disposition=attachment%3B%20filename%3Dstt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.110.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 3546255 (3.4M) [application/octet-stream]
Saving to: 'stt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl'

stt-1.3.0-cp38-cp38-manylinux_2_2 100%[=============================================================>]   3.38M  9.96MB/s    in 0.3s

2022-07-27 10:27:25 (9.96 MB/s) - 'stt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl' saved [3546255/3546255]
ubuntu@fd8a43352cf3:~$ pip install stt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl
ERROR: stt-1.3.0-cp38-cp38-manylinux_2_24_x86_64.whl is not a supported wheel on this platform.

[notice] A new release of pip available: 22.1.2 -> 22.2
[notice] To update, run: pip install --upgrade pip
ubuntu@fd8a43352cf3:~$ lscpu
Architecture:                    aarch64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   39 bits physical, 48 bits virtual
CPU(s):                          6
On-line CPU(s) list:             0-5
Thread(s) per core:              1
Core(s) per socket:              6
Socket(s):                       1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           126
Model name:                      Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
Stepping:                        5
CPU MHz:                         2304.031
BogoMIPS:                        4608.06
L1d cache:                       288 KiB
L1i cache:                       192 KiB
L2 cache:                        3 MiB
L3 cache:                        8 MiB
Vulnerability Itlb multihit:     KVM: Mitigation: VMX unsupported
Vulnerability L1tf:              Mitigation; PTE Inversion
Vulnerability Mds:               Vulnerable; SMT Host state unknown
Vulnerability Meltdown:          Vulnerable
Vulnerability Spec store bypass: Vulnerable
Vulnerability Spectre v1:        Vulnerable: __user pointer sanitization and usercopy barriers only; no swapgs barriers
Vulnerability Spectre v2:        Vulnerable, STIBP: disabled
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht sy
                                 scall nx lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid pni pclmulqdq ssse3 fma cx16 pcid ss
                                 e4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch fsgsbase bmi1 s
                                 mep bmi2 erms rdseed adx smap clflushopt sha_ni arat umip pku ospke vpclmulqdq
ubuntu@fd8a43352cf3:~$ python --version
Python 3.8.10                                 
```