### PR TITLE
Update ds-swig release URLs

### DIFF
--- a/native_client/definitions.mk
+++ b/native_client/definitions.mk
@@ -210,11 +210,11 @@ endef
 SWIG_DIST_URL ?=
 ifeq ($(SWIG_DIST_URL),)
 ifeq ($(findstring Linux,$(OS)),Linux)
-SWIG_DIST_URL := "https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/ds-swig.linux.amd64.tar.gz"
+SWIG_DIST_URL := "https://github.com/coqui-ai/STT/releases/download/v1.3.0/ds-swig.linux.amd64.tar.gz"
 else ifeq ($(findstring Darwin,$(OS)),Darwin)
-SWIG_DIST_URL := "https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/ds-swig.darwin.amd64.tar.gz"
+SWIG_DIST_URL := "https://github.com/coqui-ai/STT/releases/download/v1.3.0/ds-swig.darwin.amd64.tar.gz"
 else ifeq ($(findstring _NT,$(OS)),_NT)
-SWIG_DIST_URL := "https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/ds-swig.win.amd64.tar.gz"
+SWIG_DIST_URL := "https://github.com/coqui-ai/STT/releases/download/v1.3.0/ds-swig.win.amd64.tar.gz"
 else
 $(error There is no prebuilt SWIG available for your platform. Please produce one and set SWIG_DIST_URL.)
 endif # findstring()


### PR DESCRIPTION
This PR updates the ds-swig release URLs in the definitions.mk file to the latest ds-swig in coqui STT v1.3.0.

Without updating these URLs, building swig dependant bindings would throw the following error: `error: macro "SWIGV8_ARRAY_NEW" passed 1 arguments, but takes just 0.`. This issue came up in another [draft PR](https://github.com/coqui-ai/STT/pull/2269), which may provide more insight.

These changes were tested on linux, so any help testing them on other OSs would be greatly appreciated.
I am afraid the changes in this PR don't account for ARM architectures, whose ds-swig releases are available for download on v1.3.0 and were not availble back in DS v0.9.3. I am not sure how to add support to that, so any insights would be appreciated. 

