### PR TITLE
Resampy 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def main():
         "progressbar2",
         "protobuf <= 3.20.1",
         "pyogg >= 0.6.14a1",
-        "resampy >= 0.2.2",
+        "resampy >= 0.4.0",
         "requests",
         "semver",
         "six",


### PR DESCRIPTION
Using bmcfee/resampy in version 0.3.X produces issue #2268 This should be fixed resampy 0.4.0.
I suggest to require resampy  0.4 instead of old 0.2.2