### PR TITLE
Update brew to v3.5.9 to fix mac arm64 build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1616,7 +1616,7 @@ jobs:
           export PATH="$HOME/arm-target/bin:$PATH"
 
           cd ~/arm-target
-          mkdir arm-brew && curl -L https://github.com/Homebrew/brew/tarball/77359472938971510506cb2337a665db1d46534d | tar xz --strip 1 -C arm-brew
+          mkdir arm-brew && curl -L https://github.com/Homebrew/brew/tarball/3748bed378401ed75abdf32bcb3d2674d854a6f9 | tar xz --strip 1 -C arm-brew
 
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_CACHE=~/arm-target/brew-cache


### PR DESCRIPTION
This PR fixes the following error on the CI "Mac|Build libstt+client (arm64)" step:
```Error: Invalid formula: /Users/runner/arm-target/arm-brew/Library/Taps/homebrew/homebrew-core/Formula/mit-scheme.rb mit-scheme: undefined method `on_intel' for #<Resource:0x00007fa8b537fc98>```

This error is fixed by updating brew to the latest version, 3.5.9.