### PR TITLE
Adds direct link to quickstart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,9 @@
 * Small-footprint acoustic model.
 * Bindings for various programming languages.
 
+`Quickstart <https://stt.readthedocs.io/en/latest/#quickstart>`_
+================================================================
+
 Where to Ask Questions
 ----------------------
 


### PR DESCRIPTION
As a total newb to coqui-ai/stt and STT en general I was surprised that the quickstart wasn't easier to find.  I'm proposing adding this link so others will find it faster.

# Pull request guidelines

Welcome to the 🐸STT project! We are excited to see your interest, and appreciate your support!

This repository is governed by the Contributor Covenant Code of Conduct. For more details, see the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file.

In order to make a good pull request, please see our [CONTRIBUTING.rst](CONTRIBUTING.rst) file, in particular make sure you have set-up and run the pre-commit hook to check your changes for code style violations.

Before accepting your pull request, you will be asked to sign a [Contributor License Agreement](https://cla-assistant.io/coqui-ai/STT).

This [Contributor License Agreement](https://cla-assistant.io/coqui-ai/STT):

- Protects you, Coqui, and the users of the code.
- Does not change your rights to use your contributions for any purpose.
- Does not change the license of the 🐸STT project. It just makes the terms of your contribution clearer and lets us know you are OK to contribute.
