### PR TITLE
Updated missing checkpoint path error message

### DIFF
--- a/native_client/generate_scorer_package.cpp
+++ b/native_client/generate_scorer_package.cpp
@@ -51,7 +51,7 @@ create_package(absl::optional<string> checkpoint_path,
     }
 
     if (!force_bytes_output_mode.value() && !checkpoint_path.has_value()) {
-        cerr << "No --alphabet file specified, not using bytes output mode, can't continue.\n";
+        cerr << "No --checkpoint file specified, not using bytes output mode, can't continue.\nCheckpoint path must contains an alphabet.\nStart by creating an alphabet for your models using coqui_stt_training.util.check_characters if needed.\n\n    python -m coqui_stt_training.util.check_characters \\\n				--csv-files ... \\\n				--alphabet-format | grep -v '^#' | sort -n > models/alphabet.txt\n\nThis will create an alphabet models/alphabet.txt.\nNow rerun this script by giving models/ as the checkpoint path.\n\n    generate_scorer_package  \\\n		--checkpoint models/ \\\n		...\n";
         return 1;
     }
 

--- a/native_client/generate_scorer_package.cpp
+++ b/native_client/generate_scorer_package.cpp
@@ -51,7 +51,17 @@ create_package(absl::optional<string> checkpoint_path,
     }
 
     if (!force_bytes_output_mode.value() && !checkpoint_path.has_value()) {
-        cerr << "No --checkpoint file specified, not using bytes output mode, can't continue.\nCheckpoint path must contains an alphabet.\nStart by creating an alphabet for your models using coqui_stt_training.util.check_characters if needed.\n\n    python -m coqui_stt_training.util.check_characters \\\n				--csv-files ... \\\n				--alphabet-format | grep -v '^#' | sort -n > models/alphabet.txt\n\nThis will create an alphabet models/alphabet.txt.\nNow rerun this script by giving models/ as the checkpoint path.\n\n    generate_scorer_package  \\\n		--checkpoint models/ \\\n		...\n";
+        cerr << "No --checkpoint file specified, not using bytes output mode, can't continue."
+             << "\nCheckpoint path must contains an alphabet."
+             << "\nStart by creating an alphabet for your models using coqui_stt_training.util.check_characters if needed.\n"
+             << "\n    python -m coqui_stt_training.util.check_characters \\"
+             << "\n				--csv-files ... \\"
+             << "\n				--alphabet-format | grep -v '^#' | sort -n > models/alphabet.txt\n"
+             << "\nThis will create an alphabet models/alphabet.txt.\n"
+             << "Now rerun this script by giving models/ as the checkpoint path.\n"
+             << "\n    generate_scorer_package  \\"
+             << "\n		--checkpoint models/ \\"
+             << "\n		...\n";
         return 1;
     }
 


### PR DESCRIPTION
Addresses https://github.com/coqui-ai/STT/issues/2329

```
generate_scorer_package --lm /mnt/lm/lm.binary --vocab /mnt/lm/vocab-500000.txt --package /mnt/lm/kenlm.scorer --default_alpha 0 --default_beta 0
500000 unique words read from vocabulary file.
Doesn't look like a character based (Bytes Are All You Need) model.
--force_bytes_output_mode was not specified, using value infered from vocabulary contents: false
No --checkpoint file specified, not using bytes output mode, can't continue.
Checkpoint path must contains an alphabet.
Start by creating an alphabet for your models using coqui_stt_training.util.check_characters if needed.

    python -m coqui_stt_training.util.check_characters \
                                --csv-files ... \
                                --alphabet-format | grep -v '^#' | sort -n > models/alphabet.txt

This will create an alphabet models/alphabet.txt.
Now rerun this script by giving models/ as the checkpoint path.

    generate_scorer_package  \
                --checkpoint models/ \
                ...
```

[Full logs](https://gist.github.com/wasertech/7c7b2690d679e441ff79131c8fbf085c)